### PR TITLE
Restores the collection logic to something more funcitonal

### DIFF
--- a/bin/clip
+++ b/bin/clip
@@ -1,18 +1,24 @@
 #!/bin/bash
 
-# Check if a path is provided
-if [ -z "$1" ]; then
-  echo "Usage: clip <path_to_file>"
-  exit 1
+# Define the system's clipboard command
+if [[ "$(uname)" == "Darwin" ]]; then
+    CLIP_CMD="pbcopy"
+elif command -v xclip >/dev/null 2>&1; then
+    CLIP_CMD="xclip -selection clipboard"
+else
+    echo "Error: No clipboard utility found (pbcopy or xclip)." >&2
+    exit 1
 fi
 
-# Check if the file exists
-if [ ! -f "$1" ]; then
-  echo "File not found!"
-  exit 1
+# If an argument is provided, check if it's a file and cat it
+if [ -n "$1" ]; then
+    if [ -f "$1" ]; then
+        cat "$1" | $CLIP_CMD
+    else
+        echo "File not found: $1" >&2
+        exit 1
+    fi
+# If no argument, read from stdin (for tmux piping)
+else
+    cat | $CLIP_CMD
 fi
-
-# Copy the file contents to the clipboard
-cat "$1" | pbcopy
-
-echo "File contents copied to clipboard."

--- a/log-hoarder/tmux.conf
+++ b/log-hoarder/tmux.conf
@@ -7,25 +7,6 @@
 #   - TDS_LOG_DIR set in environment before tmux starts
 #   - ansifilter installed (brew install ansifilter) for clean log output
 
-# --- General settings ---
-
-set -g mouse on
-
-# Don't exit copy mode when scrolling to the bottom of the pane.
-# Default uses copy-mode -e which auto-exits, killing any active selection.
-bind -T root WheelUpPane if-shell -F "#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode }
-
-# xterm-style selection: left-click starts, right-click extends and copies.
-# Mouse events move the cursor to the click position before the bound
-# command runs, so right-click at point B copies the region A→B.
-bind -T copy-mode MouseDown1Pane select-pane \; send-keys -X begin-selection
-# Right-click in copy mode: copy selection to clipboard and exit.
-# Outside copy mode, right-click shows the default tmux context menu.
-bind -T copy-mode MouseDown3Pane send-keys -X copy-pipe-and-cancel "pbcopy"
-# Don't auto-copy on drag release — let user review the selection first.
-bind -T copy-mode MouseDragEnd1Pane send-keys -X stop-selection
-bind -T copy-mode M-w send-keys -X copy-pipe-and-cancel "pbcopy"
-
 # --- Auto-logging hooks ---
 # Fire the logging script for every new pane surface.
 

--- a/log-hoarder/tmux.conf
+++ b/log-hoarder/tmux.conf
@@ -16,16 +16,17 @@ set -g mode-keys emacs
 # Default uses copy-mode -e which auto-exits, killing any active selection.
 bind -T root WheelUpPane if-shell -F "#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode }
 
-# xterm-style selection: left-click sets anchor, right-click copies and exits.
+# Seesaw selection: left-click sets anchor, selection stays live.
+# Subsequent left-clicks move the cursor end (seesaw).
 bind -T copy-mode MouseDown1Pane select-pane \; send-keys -X begin-selection
-# Drag extends from anchor; release keeps selection visible (no auto-copy).
-bind -T copy-mode MouseDragEnd1Pane send-keys -X stop-selection
-# Right-click: copy selection to clipboard and exit copy mode.
+# Drag extends; release keeps selection live (no stop, no copy).
+unbind -T copy-mode MouseDragEnd1Pane
+# Right-click copies selection to clipboard and exits copy mode.
 bind -T copy-mode MouseDown3Pane send-keys -X copy-pipe-and-cancel "clip"
-# Double-click selects word, triple-click selects line — both keep selection.
+# Double-click selects word, triple-click selects line — selection stays live.
 bind -T copy-mode DoubleClick1Pane select-pane \; send-keys -X select-word
 bind -T copy-mode TripleClick1Pane select-pane \; send-keys -X select-line
-# M-w copies and exits (emacs yank).
+# M-w copies to clipboard and exits copy mode.
 bind -T copy-mode M-w send-keys -X copy-pipe-and-cancel "clip"
 
 # --- Auto-logging hooks ---

--- a/log-hoarder/tmux.conf
+++ b/log-hoarder/tmux.conf
@@ -7,6 +7,26 @@
 #   - TDS_LOG_DIR set in environment before tmux starts
 #   - ansifilter installed (brew install ansifilter) for clean log output
 
+# --- General settings ---
+
+set -g mouse on
+
+# Don't exit copy mode when scrolling to the bottom of the pane.
+# Default uses copy-mode -e which auto-exits, killing any active selection.
+bind -T root WheelUpPane if-shell -F "#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode }
+
+# xterm-style selection: left-click starts, right-click extends and copies.
+# Mouse events move the cursor to the click position before the bound
+# command runs, so right-click at point B copies the region A→B.
+bind -T copy-mode MouseDown1Pane select-pane \; send-keys -X begin-selection
+# Right-click extends selection to click point (without copying).
+# select-pane moves cursor to click position; active selection extends to follow.
+# Use M-w to copy when satisfied.
+bind -T copy-mode MouseDown3Pane select-pane
+# Don't auto-copy on drag release — let user review the selection first.
+bind -T copy-mode MouseDragEnd1Pane send-keys -X stop-selection
+bind -T copy-mode M-w send-keys -X copy-pipe-and-cancel "pbcopy"
+
 # --- Auto-logging hooks ---
 # Fire the logging script for every new pane surface.
 

--- a/log-hoarder/tmux.conf
+++ b/log-hoarder/tmux.conf
@@ -7,6 +7,27 @@
 #   - TDS_LOG_DIR set in environment before tmux starts
 #   - ansifilter installed (brew install ansifilter) for clean log output
 
+# --- General settings ---
+
+set -g mouse on
+set -g mode-keys emacs
+
+# Don't exit copy mode when scrolling to the bottom of the pane.
+# Default uses copy-mode -e which auto-exits, killing any active selection.
+bind -T root WheelUpPane if-shell -F "#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode }
+
+# xterm-style selection: left-click sets anchor, right-click copies and exits.
+bind -T copy-mode MouseDown1Pane select-pane \; send-keys -X begin-selection
+# Drag extends from anchor; release keeps selection visible (no auto-copy).
+bind -T copy-mode MouseDragEnd1Pane send-keys -X stop-selection
+# Right-click: copy selection to clipboard and exit copy mode.
+bind -T copy-mode MouseDown3Pane send-keys -X copy-pipe-and-cancel "clip"
+# Double-click selects word, triple-click selects line — both keep selection.
+bind -T copy-mode DoubleClick1Pane select-pane \; send-keys -X select-word
+bind -T copy-mode TripleClick1Pane select-pane \; send-keys -X select-line
+# M-w copies and exits (emacs yank).
+bind -T copy-mode M-w send-keys -X copy-pipe-and-cancel "clip"
+
 # --- Auto-logging hooks ---
 # Fire the logging script for every new pane surface.
 

--- a/log-hoarder/tmux.conf
+++ b/log-hoarder/tmux.conf
@@ -19,10 +19,9 @@ bind -T root WheelUpPane if-shell -F "#{||:#{alternate_on},#{pane_in_mode},#{mou
 # Mouse events move the cursor to the click position before the bound
 # command runs, so right-click at point B copies the region A→B.
 bind -T copy-mode MouseDown1Pane select-pane \; send-keys -X begin-selection
-# Right-click extends selection to click point (without copying).
-# select-pane moves cursor to click position; active selection extends to follow.
-# Use M-w to copy when satisfied.
-bind -T copy-mode MouseDown3Pane select-pane
+# Right-click in copy mode: copy selection to clipboard and exit.
+# Outside copy mode, right-click shows the default tmux context menu.
+bind -T copy-mode MouseDown3Pane send-keys -X copy-pipe-and-cancel "pbcopy"
 # Don't auto-copy on drag release — let user review the selection first.
 bind -T copy-mode MouseDragEnd1Pane send-keys -X stop-selection
 bind -T copy-mode M-w send-keys -X copy-pipe-and-cancel "pbcopy"

--- a/test/debug_tmux_mouse.sh
+++ b/test/debug_tmux_mouse.sh
@@ -1,0 +1,42 @@
+#!/bin/zsh
+# debug_tmux_mouse.sh — dump tmux mouse-related config and bindings
+set -euo pipefail
+
+echo "=== tmux version ==="
+tmux -V
+
+echo ""
+echo "=== mouse setting ==="
+tmux show -g mouse
+
+echo ""
+echo "=== default-terminal ==="
+tmux show -g default-terminal
+
+echo ""
+echo "=== terminal-features ==="
+tmux show -g terminal-features 2>/dev/null || echo "(not set)"
+
+echo ""
+echo "=== TERM inside tmux ==="
+echo "TERM=$TERM"
+
+echo ""
+echo "=== copy-mode key table (mouse bindings) ==="
+tmux list-keys -T copy-mode | grep -i mouse
+
+echo ""
+echo "=== copy-mode-vi key table (mouse bindings) ==="
+tmux list-keys -T copy-mode-vi | grep -i mouse 2>/dev/null || echo "(none)"
+
+echo ""
+echo "=== root key table (mouse bindings) ==="
+tmux list-keys -T root | grep -i mouse
+
+echo ""
+echo "=== mode-keys setting ==="
+tmux show -g mode-keys
+
+echo ""
+echo "=== all copy-mode bindings ==="
+tmux list-keys -T copy-mode


### PR DESCRIPTION
Xterm selection isn't possible with tmux as-is as there's no way to set (or even look up) the anchor point, just cursor.

Just need to embrace the seesaw selection method...