### PR TITLE
Add orphan sweep to shepherd cron mode

### DIFF
--- a/log-hoarder/tmux_shepherd.sh
+++ b/log-hoarder/tmux_shepherd.sh
@@ -108,6 +108,8 @@ run_cron_mode() {
     arch=$(archived_dir)
     diag_log "cron sweep started: ${arch}"
 
+    sweep_orphans
+
     local count=0
     for panedir in "${arch}"/*/*/*(N/); do
         if is_unbranded "${panedir}"; then


### PR DESCRIPTION
## Summary
- `run_cron_mode` only branded already-archived logs but never called `sweep_orphans()`, so dead sessions accumulated in `active/` indefinitely between hook invocations
- Now calls `sweep_orphans()` before the branding pass
- Verified manually: 13 orphaned session dirs were correctly swept and archived while the live session (66) was left untouched

## Test plan
- [x] Ran shepherd with no args against real `active/` dir with 13 dead sessions and 1 live session
- [x] Confirmed all dead sessions archived, live session preserved
- [ ] Existing smoketest in `test/smoketest_log_hoarder.sh` should still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)