### PR TITLE
Sync agent/prompt docs with template-base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ emacs/dot.emacs.d/projects
 
 emacs/dot.emacs.d/elisp/emacs-mcp-server/
 .claude
+memory/

--- a/AGENT.md
+++ b/AGENT.md
@@ -20,6 +20,9 @@ See README.tds for the original description.
   design before producing code. Wait for approval.
 - **Ask clarifying questions** about placement, naming, conventions, and scope
   before starting work.
+- **Solve problems, don't work around them.** When a tool, command, or workflow
+  produces broken output, diagnose the root cause and fix it. Do not silently
+  switch to a different tool or manual approach to avoid the issue.
 
 ## Platform & Shell
 

--- a/prompts/GITHUB.md
+++ b/prompts/GITHUB.md
@@ -97,6 +97,13 @@ When addressing PR review feedback:
 - Run `gadmin github pending-comments --repo <OWNER/REPO> --pr <NUMBER>`
 - Output should be empty (no unaddressed comments)
 
+**Step 7: Consider documentation updates**
+- Did an accepted fix reveal a gap worth documenting (new TODO, design change)?
+- Did a rejected suggestion surface a lesson worth recording (tool behavior,
+  design decision, recurring reviewer misconception)?
+- If yes, update relevant docs and include in the next commit. If nothing
+  was noteworthy, skip this step.
+
 **Execution notes:**
 - Run reply commands **sequentially** (one per tool call) — do NOT batch
 - If `gadmin github` fails, fall back to `gadmin github-octokit`, then `gadmin github-gitapi` as last resort


### PR DESCRIPTION
## Summary
- **AGENT.md**: Added "solve problems, don't work around them" workflow rule (was already in CLAUDE.md, now consistent)
- **prompts/GITHUB.md**: Folded in Step 7 from template-base — prompts reviewers to consider documentation updates after addressing PR feedback
- **.gitignore**: Added `memory/` to exclude Claude auto-memory directory from version control

## Notes on template-base delta
The remaining differences between our prompts/ and template-base are intentional:
- Our files use ASCII `--` instead of em-dashes (consistent with our SKILL.MARKDOWN.md rules)
- Our files use `->` and `[NO]`/`[OK]` instead of `→` and emoji markers (ASCII-only policy)
- The `gadmin` path clarifications in template-base GITHUB.md reference `scripts/admin/` which doesn't exist here

## Test plan
- [ ] Verify .gitignore excludes `memory/` from tracking
- [ ] Review GITHUB.md Step 7 wording is appropriate for this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)