### PR TITLE
feat(log-hoarder): ctrl-x s ZLE widget for semantic log search

### DIFF
--- a/TODO_PLAN.md
+++ b/TODO_PLAN.md
@@ -24,7 +24,7 @@ This file tracks the status of development tasks, lessons learned, and completed
 
 ### Shell Integration
 
-- [ ] Task Z1: Create ZLE widget for `ctrl-x s` — invokes `log_search`, pipes results through `fzf` for selection, displays matched log section in `$PAGER`. Add to `macos/dot.zshrc` or a sourced plugin file.
+- [x] Task Z1: Create ZLE widget for `ctrl-x s` — invokes `log_search`, pipes results through `fzf` for selection, displays matched log section in `$PAGER`. Plugin file `macos/dot.zsh_log_search`, sourced from `dot.zshrc`. PR #12.
 
 ### Pipeline (implementation work driven by smoke tests above)
 

--- a/log-hoarder/search/cli/search.py
+++ b/log-hoarder/search/cli/search.py
@@ -21,7 +21,7 @@ def run_search(query: str) -> None:
     )
 
     index = TxtaiAdapter(index_path=index_path)
-    matches = index.search(query, limit=5)
+    matches = index.search(query, limit=10)
 
     if not matches:
         return

--- a/macos/dot.zsh_log_search
+++ b/macos/dot.zsh_log_search
@@ -1,0 +1,98 @@
+#!/bin/zsh
+# dot.zsh_log_search — ZLE widget for semantic search over terminal session logs
+#
+# Binds ctrl-x s to invoke log_search via fzf, then opens the selected
+# session log in $PAGER.
+#
+# Flow:
+#   1. If the line buffer has text, use it as the query. Otherwise prompt.
+#   2. Run log_search with the query (semantic search).
+#   3. Pipe ranked results through fzf for selection.
+#   4. Open the selected session's log files in $PAGER.
+#
+# Prerequisites: fzf, log_search (in PATH via tds-utils/bin/)
+#
+# Source this file from .zshrc:
+#   source ~/workplace/tds-utils/macos/dot.zsh_log_search
+
+# --- Widget ---
+
+_log_search_widget() {
+    # Guard: fzf required.
+    if ! command -v fzf >/dev/null 2>&1; then
+        zle -M "log_search: fzf not found — install with: brew install fzf"
+        return 1
+    fi
+
+    # Guard: log_search required.
+    if ! command -v log_search >/dev/null 2>&1; then
+        zle -M "log_search: log_search not found in PATH"
+        return 1
+    fi
+
+    local query="${BUFFER}"
+
+    # If the line buffer is empty, prompt for a query via /dev/tty.
+    if [[ -z "${query}" ]]; then
+        print -n "log search: " >/dev/tty
+        read -r query </dev/tty
+
+        if [[ -z "${query}" ]]; then
+            zle reset-prompt
+            return 0
+        fi
+    fi
+
+    # Clear the buffer so the query text doesn't linger.
+    BUFFER=""
+    zle reset-prompt
+
+    # Run semantic search, pipe through fzf for selection.
+    # log_search output: SESSION_PATH\tSCORE\tTIMESTAMP\tSLUG
+    zle -M "Searching..."
+    local selected
+    selected=$(
+        log_search "${query}" 2>/dev/null |
+        fzf --ansi \
+            --no-sort \
+            --delimiter='\t' \
+            --with-nth=1,3,4 \
+            --header="Results for: ${query}" \
+            --preview='head -c 4000 {1}/*.log 2>/dev/null | head -80' \
+            --preview-window=right:50%:wrap \
+            --height=60% \
+            --reverse \
+        </dev/tty
+    )
+
+    zle reset-prompt
+
+    if [[ -z "${selected}" ]]; then
+        return 0
+    fi
+
+    # Extract session path (first tab-delimited field).
+    local session_path
+    session_path=$(print "${selected}" | cut -f1)
+
+    if [[ ! -d "${session_path}" ]]; then
+        zle -M "log_search: session path not found: ${session_path}"
+        return 1
+    fi
+
+    # Open the log file(s) in $PAGER.
+    local -a log_files
+    log_files=("${session_path}"/*.log(N))
+
+    if (( ${#log_files} == 0 )); then
+        zle -M "log_search: no .log files in ${session_path}"
+        return 1
+    fi
+
+    ${PAGER:-less} "${log_files[@]}" </dev/tty
+    zle reset-prompt
+}
+
+# Register the widget and bind to ctrl-x s.
+zle -N _log_search_widget
+bindkey '^Xs' _log_search_widget

--- a/macos/dot.zshrc
+++ b/macos/dot.zshrc
@@ -81,6 +81,11 @@ source ~/workplace/lab54/grubsta/scripts/completions/grubsta-completions.zsh
 # Path updates
 export PATH="/Users/stumpf/.antigravity/antigravity/bin:$PATH"
 
+# log-hoarder: semantic search widget (ctrl-x s)
+if [[ -f ~/workplace/tds-utils/macos/dot.zsh_log_search ]]; then
+    source ~/workplace/tds-utils/macos/dot.zsh_log_search
+fi
+
 # log-hoarder: auto-launch tmux for each new terminal window.
 # (1Password ENV is inherited by tmux because it is exported above)
 if [[ -o interactive ]] && [[ -z "$TMUX" ]]; then


### PR DESCRIPTION
## Summary

- Adds `macos/dot.zsh_log_search` — ZLE widget bound to `ctrl-x s`
- Uses current line buffer as query, or prompts interactively if empty
- Pipes `log_search` results through `fzf` with session log preview
- Opens selected session in `$PAGER`
- Sources the plugin from `dot.zshrc` (before the tmux auto-launch guard)
- Bumps search result limit from 5 to 10

## Setup to kick the tires

```sh
brew install fzf
log_index          # build the default index (one-time, ~30s)
```

Then in any terminal: type a query and press `ctrl-x s`, or press `ctrl-x s` with an empty line to get prompted.

## Test plan

- [x] `./test/smoketest_log_search/run_all.sh` — 3/3 pass
- [ ] Manual: source dot.zsh_log_search, press ctrl-x s, verify fzf opens with results
- [ ] Manual: select a result, verify log opens in less
- [ ] Manual: press ctrl-x s with text in buffer, verify it's used as query
- [ ] Manual: press ctrl-x s with empty buffer, verify prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)