### PR TITLE
feat(goldfish): G2 --llm, G3 cache, G5 --json, G6 -v, G7 org filters, G4 smoke tests

### DIFF
--- a/goldfish/core.py
+++ b/goldfish/core.py
@@ -203,6 +203,24 @@ def sort_rows(rows: Iterable[RepoRow], *, now: datetime | None = None) -> list[R
     return sorted(rows, key=key, reverse=True)
 
 
+# --- Verbose process listing (G6) --------------------------------------------
+
+def format_processes(sessions: Iterable[AgentSession]) -> str:
+    """Render processes-in-tracked-repos as a per-repo block. Empty input -> ''."""
+    sessions = list(sessions)
+    if not sessions:
+        return ""
+    by_repo: dict[Path, list[AgentSession]] = {}
+    for s in sessions:
+        by_repo.setdefault(s.repo_path, []).append(s)
+    lines = ["PROCESSES IN TRACKED REPOS"]
+    for repo in sorted(by_repo):
+        lines.append(f"  {repo}")
+        for s in sorted(by_repo[repo], key=lambda x: x.pid):
+            lines.append(f"    {s.pid:>7}  {s.name}")
+    return "\n".join(lines)
+
+
 # --- Org filter (G7) ---------------------------------------------------------
 
 def apply_org_filter(

--- a/goldfish/core.py
+++ b/goldfish/core.py
@@ -203,6 +203,32 @@ def sort_rows(rows: Iterable[RepoRow], *, now: datetime | None = None) -> list[R
     return sorted(rows, key=key, reverse=True)
 
 
+# --- LLM output cleanup (G2) -------------------------------------------------
+
+LLM_LINE_MAX = 200
+
+
+def first_meaningful_line(raw: str) -> str | None:
+    """Return the first non-empty line, stripped of leading bullets/quotes.
+
+    Bounded to LLM_LINE_MAX chars so a chatty model can't blow up the table.
+    """
+    for line in raw.splitlines():
+        cleaned = line.strip()
+        if not cleaned:
+            continue
+        for prefix in ("- ", "* ", "• "):
+            if cleaned.startswith(prefix):
+                cleaned = cleaned[len(prefix):]
+                break
+        if len(cleaned) >= 2 and cleaned[0] == cleaned[-1] and cleaned[0] in ('"', "'"):
+            cleaned = cleaned[1:-1]
+        if len(cleaned) > LLM_LINE_MAX:
+            cleaned = cleaned[:LLM_LINE_MAX]
+        return cleaned or None
+    return None
+
+
 # --- Clones cache (G3) -------------------------------------------------------
 
 CLONES_CACHE_VERSION = 1

--- a/goldfish/core.py
+++ b/goldfish/core.py
@@ -203,6 +203,71 @@ def sort_rows(rows: Iterable[RepoRow], *, now: datetime | None = None) -> list[R
     return sorted(rows, key=key, reverse=True)
 
 
+# --- Org filter (G7) ---------------------------------------------------------
+
+def apply_org_filter(
+    rows: Iterable[RepoRow],
+    *,
+    include: tuple[str, ...],
+    exclude: tuple[str, ...],
+) -> list[RepoRow]:
+    """Filter rows by owner. include='' means no allow-list; exclude wins ties."""
+    excluded = set(exclude)
+    included = set(include)
+    out: list[RepoRow] = []
+    for row in rows:
+        owner = row.name.split("/", 1)[0] if "/" in row.name else ""
+        if owner in excluded:
+            continue
+        if included and owner not in included:
+            continue
+        out.append(row)
+    return out
+
+
+# --- JSON serialization (G5) -------------------------------------------------
+
+def rows_to_json(rows: Iterable[RepoRow]) -> str:
+    """Render rows as a JSON array. Stable shape for piping into other tools."""
+    return json.dumps([_row_to_jsonable(r) for r in rows], indent=2, sort_keys=True)
+
+
+def _row_to_jsonable(r: RepoRow) -> dict:
+    return {
+        "name": r.name,
+        "github": _github_to_jsonable(r.github),
+        "local": _local_to_jsonable(r.local),
+        "agents": [
+            {"pid": a.pid, "name": a.name, "repo_path": str(a.repo_path)}
+            for a in r.agents
+        ],
+    }
+
+
+def _github_to_jsonable(g: GithubInfo | None) -> dict | None:
+    if g is None:
+        return None
+    return {
+        "name": g.name,
+        "pushed_at": g.pushed_at.isoformat() if g.pushed_at else None,
+        "open_pr_count": g.open_pr_count,
+    }
+
+
+def _local_to_jsonable(l: LocalInfo | None) -> dict | None:
+    if l is None:
+        return None
+    return {
+        "path": str(l.path),
+        "is_dirty": l.is_dirty,
+        "ahead": l.ahead,
+        "behind": l.behind,
+        "branch": l.branch,
+        "last_commit_at": l.last_commit_at.isoformat() if l.last_commit_at else None,
+        "next_task": l.next_task,
+    }
+
+
 # --- Formatter ---------------------------------------------------------------
 
 _HEADERS = ("REPO", "PRS", "DIRTY", "AHEAD", "BRANCH", "AGENTS", "NEXT")

--- a/goldfish/core.py
+++ b/goldfish/core.py
@@ -203,6 +203,51 @@ def sort_rows(rows: Iterable[RepoRow], *, now: datetime | None = None) -> list[R
     return sorted(rows, key=key, reverse=True)
 
 
+# --- Clones cache (G3) -------------------------------------------------------
+
+CLONES_CACHE_VERSION = 1
+
+
+@dataclass(frozen=True, slots=True)
+class ClonesCache:
+    saved_at: datetime
+    clones: dict[str, Path]
+
+
+def serialize_clones_cache(clones: dict[str, Path], *, saved_at: datetime) -> str:
+    """Render the clones map as JSON for `$XDG_CACHE_HOME/goldfish/clones.json`."""
+    return json.dumps({
+        "version": CLONES_CACHE_VERSION,
+        "saved_at": saved_at.isoformat(),
+        "clones": {name: str(path) for name, path in sorted(clones.items())},
+    }, indent=2)
+
+
+def parse_clones_cache(text: str) -> ClonesCache | None:
+    """Parse a clones cache file. Returns None if malformed or wrong version."""
+    try:
+        data = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    if data.get("version") != CLONES_CACHE_VERSION:
+        return None
+    raw_saved = data.get("saved_at")
+    raw_clones = data.get("clones")
+    if not isinstance(raw_saved, str) or not isinstance(raw_clones, dict):
+        return None
+    try:
+        saved = _parse_iso(raw_saved)
+    except ValueError:
+        return None
+    clones: dict[str, Path] = {}
+    for name, path in raw_clones.items():
+        if isinstance(name, str) and isinstance(path, str):
+            clones[name] = Path(path)
+    return ClonesCache(saved_at=saved, clones=clones)
+
+
 # --- Verbose process listing (G6) --------------------------------------------
 
 def format_processes(sessions: Iterable[AgentSession]) -> str:

--- a/goldfish/goldfish
+++ b/goldfish/goldfish
@@ -77,7 +77,12 @@ def resolve_orgs(config: dict) -> list[str]:
 # --- Progress bar ------------------------------------------------------------
 
 class Progress:
-    """Single-line stderr progress display. No-op when stderr isn't a tty."""
+    """Single-line stderr progress display.
+
+    Informational messages (`msg`) always emit so logs/CI/test-pipes capture
+    them. Only the animated progress bar (`step`) is tty-gated, since its
+    \\r-overwriting carriage returns look ugly in non-tty output.
+    """
 
     def __init__(self) -> None:
         self.tty = sys.stderr.isatty()

--- a/goldfish/goldfish
+++ b/goldfish/goldfish
@@ -20,7 +20,14 @@ from pathlib import Path
 HERE = Path(__file__).resolve().parent
 sys.path.insert(0, str(HERE))
 
-from core import GithubInfo, RepoRow, format_table, sort_rows  # noqa: E402
+from core import (  # noqa: E402
+    GithubInfo,
+    RepoRow,
+    apply_org_filter,
+    format_table,
+    rows_to_json,
+    sort_rows,
+)
 from shell import (  # noqa: E402
     fetch_remote_todo_plan,
     find_local_clones,
@@ -191,6 +198,18 @@ def run(argv: list[str]) -> int:
         "--max-width", type=int, default=_terminal_width(),
         help="Max line width for the rendered table.",
     )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Emit a JSON array instead of a rendered table.",
+    )
+    parser.add_argument(
+        "--include-org", action="append", default=[], metavar="ORG",
+        help="Only show repos owned by this org. Repeatable.",
+    )
+    parser.add_argument(
+        "--exclude-org", action="append", default=[], metavar="ORG",
+        help="Hide repos owned by this org. Repeatable. Wins over --include-org.",
+    )
     args = parser.parse_args(argv)
 
     if not have("gh"):
@@ -200,11 +219,22 @@ def run(argv: list[str]) -> int:
 
     config = load_config()
     rows = gather(config, fetch_remote_todos=args.fetch_remote_todos)
+    rows = apply_org_filter(
+        rows,
+        include=tuple(args.include_org),
+        exclude=tuple(args.exclude_org),
+    )
     rows = sort_rows(rows)
     if not rows:
-        print("(no repos found — check config.json or `gh auth status`)")
+        if args.json:
+            print("[]")
+        else:
+            print("(no repos found — check config.json or `gh auth status`)")
         return 0
-    print(format_table(rows, max_width=args.max_width))
+    if args.json:
+        print(rows_to_json(rows))
+    else:
+        print(format_table(rows, max_width=args.max_width))
     return 0
 
 

--- a/goldfish/goldfish
+++ b/goldfish/goldfish
@@ -31,13 +31,16 @@ from core import (  # noqa: E402
 )
 from shell import (  # noqa: E402
     all_processes_in_clones,
+    cached_clones_fresh,
     fetch_remote_todo_plan,
     find_local_clones,
     gh_list_repos,
     gh_open_pr_counts,
     have,
     inspect_local,
+    load_cached_clones,
     running_agents,
+    save_cached_clones,
 )
 from core import parse_todo_plan  # noqa: E402
 
@@ -103,7 +106,7 @@ class Progress:
 
 # --- Flow functions ----------------------------------------------------------
 
-def gather(config: dict, *, fetch_remote_todos: bool) -> tuple[list[RepoRow], dict[str, Path]]:
+def gather(config: dict, *, fetch_remote_todos: bool, refresh_clones: bool = False) -> tuple[list[RepoRow], dict[str, Path]]:
     """Run all probes and assemble RepoRows. Returns (rows, clones)."""
     progress = Progress()
     orgs = resolve_orgs(config)
@@ -112,10 +115,22 @@ def gather(config: dict, *, fetch_remote_todos: bool) -> tuple[list[RepoRow], di
 
     progress.msg(f"goldfish — orgs={orgs or '(none)'} roots={[str(r) for r in roots]}")
 
+    cached = None if refresh_clones else load_cached_clones()
+    use_cache = cached is not None and cached_clones_fresh(cached)
+    if use_cache:
+        progress.msg(f"goldfish — using cached clones ({len(cached.clones)} entries; --refresh to rescan)")
+
+    def _clones() -> dict[str, Path]:
+        if use_cache:
+            return dict(cached.clones)
+        found = find_local_clones(roots)
+        save_cached_clones(found)
+        return found
+
     with ThreadPoolExecutor(max_workers=4) as ex:
         f_gh_repos = ex.submit(gh_list_repos, orgs)
         f_gh_prs = ex.submit(gh_open_pr_counts, orgs)
-        f_clones = ex.submit(find_local_clones, roots)
+        f_clones = ex.submit(_clones)
         gh_repos = f_gh_repos.result()
         pr_counts = f_gh_prs.result()
         clones = f_clones.result()
@@ -216,6 +231,10 @@ def run(argv: list[str]) -> int:
         "-v", "--verbose", action="store_true",
         help="Also list every process whose cwd is in a tracked repo.",
     )
+    parser.add_argument(
+        "--refresh", action="store_true",
+        help="Rescan disk for clones instead of using the cache.",
+    )
     args = parser.parse_args(argv)
 
     if not have("gh"):
@@ -224,7 +243,11 @@ def run(argv: list[str]) -> int:
         )
 
     config = load_config()
-    rows, clones = gather(config, fetch_remote_todos=args.fetch_remote_todos)
+    rows, clones = gather(
+        config,
+        fetch_remote_todos=args.fetch_remote_todos,
+        refresh_clones=args.refresh,
+    )
     rows = apply_org_filter(
         rows,
         include=tuple(args.include_org),

--- a/goldfish/goldfish
+++ b/goldfish/goldfish
@@ -24,11 +24,13 @@ from core import (  # noqa: E402
     GithubInfo,
     RepoRow,
     apply_org_filter,
+    format_processes,
     format_table,
     rows_to_json,
     sort_rows,
 )
 from shell import (  # noqa: E402
+    all_processes_in_clones,
     fetch_remote_todo_plan,
     find_local_clones,
     gh_list_repos,
@@ -101,8 +103,8 @@ class Progress:
 
 # --- Flow functions ----------------------------------------------------------
 
-def gather(config: dict, *, fetch_remote_todos: bool) -> list[RepoRow]:
-    """Run all probes and assemble RepoRows."""
+def gather(config: dict, *, fetch_remote_todos: bool) -> tuple[list[RepoRow], dict[str, Path]]:
+    """Run all probes and assemble RepoRows. Returns (rows, clones)."""
     progress = Progress()
     orgs = resolve_orgs(config)
     roots = resolve_roots(config)
@@ -136,7 +138,7 @@ def gather(config: dict, *, fetch_remote_todos: bool) -> list[RepoRow]:
     total = len(todo)
     if total == 0:
         progress.done()
-        return []
+        return [], clones
 
     with ThreadPoolExecutor(max_workers=8) as ex:
         futures = {
@@ -152,7 +154,7 @@ def gather(config: dict, *, fetch_remote_todos: bool) -> list[RepoRow]:
             if row is not None:
                 rows.append(row)
     progress.done()
-    return rows
+    return rows, clones
 
 
 def _build_row(
@@ -210,6 +212,10 @@ def run(argv: list[str]) -> int:
         "--exclude-org", action="append", default=[], metavar="ORG",
         help="Hide repos owned by this org. Repeatable. Wins over --include-org.",
     )
+    parser.add_argument(
+        "-v", "--verbose", action="store_true",
+        help="Also list every process whose cwd is in a tracked repo.",
+    )
     args = parser.parse_args(argv)
 
     if not have("gh"):
@@ -218,7 +224,7 @@ def run(argv: list[str]) -> int:
         )
 
     config = load_config()
-    rows = gather(config, fetch_remote_todos=args.fetch_remote_todos)
+    rows, clones = gather(config, fetch_remote_todos=args.fetch_remote_todos)
     rows = apply_org_filter(
         rows,
         include=tuple(args.include_org),
@@ -235,6 +241,11 @@ def run(argv: list[str]) -> int:
         print(rows_to_json(rows))
     else:
         print(format_table(rows, max_width=args.max_width))
+        if args.verbose:
+            section = format_processes(all_processes_in_clones(clones))
+            if section:
+                print()
+                print(section)
     return 0
 
 

--- a/goldfish/goldfish
+++ b/goldfish/goldfish
@@ -41,6 +41,7 @@ from shell import (  # noqa: E402
     load_cached_clones,
     running_agents,
     save_cached_clones,
+    summarize_with_llm,
 )
 from core import parse_todo_plan  # noqa: E402
 
@@ -106,7 +107,13 @@ class Progress:
 
 # --- Flow functions ----------------------------------------------------------
 
-def gather(config: dict, *, fetch_remote_todos: bool, refresh_clones: bool = False) -> tuple[list[RepoRow], dict[str, Path]]:
+def gather(
+    config: dict,
+    *,
+    fetch_remote_todos: bool,
+    refresh_clones: bool = False,
+    llm: bool = False,
+) -> tuple[list[RepoRow], dict[str, Path]]:
     """Run all probes and assemble RepoRows. Returns (rows, clones)."""
     progress = Progress()
     orgs = resolve_orgs(config)
@@ -158,7 +165,7 @@ def gather(config: dict, *, fetch_remote_todos: bool, refresh_clones: bool = Fal
     with ThreadPoolExecutor(max_workers=8) as ex:
         futures = {
             ex.submit(_build_row, name, gh, pr_counts, clones, agents,
-                      fetch_remote_todos): name
+                      fetch_remote_todos, llm): name
             for name, gh in todo
         }
         done = 0
@@ -179,6 +186,7 @@ def _build_row(
     clones: dict[str, Path],
     agents: list,
     fetch_remote_todos: bool,
+    llm: bool,
 ) -> RepoRow | None:
     github_info = None
     if gh is not None:
@@ -189,14 +197,33 @@ def _build_row(
         )
     workdir = clones.get(name)
     local = inspect_local(workdir) if workdir else None
+    todo_text: str | None = None
+    if local is not None and workdir is not None:
+        todo_path = workdir / "TODO_PLAN.md"
+        if todo_path.exists():
+            try:
+                todo_text = todo_path.read_text()
+            except (OSError, UnicodeDecodeError):
+                todo_text = None
     if local is None and fetch_remote_todos and gh is not None:
         text = fetch_remote_todo_plan(name)
         if text:
             from core import LocalInfo
+            todo_text = text
             local = LocalInfo(
                 path=Path(""), is_dirty=False, ahead=0, behind=0,
                 branch="", last_commit_at=None,
                 next_task=parse_todo_plan(text),
+            )
+    if llm and todo_text and local is not None:
+        summary = summarize_with_llm(todo_text)
+        if summary:
+            from core import LocalInfo
+            local = LocalInfo(
+                path=local.path, is_dirty=local.is_dirty, ahead=local.ahead,
+                behind=local.behind, branch=local.branch,
+                last_commit_at=local.last_commit_at,
+                next_task=summary,
             )
     repo_agents = tuple(a for a in agents if workdir is not None and a.repo_path == workdir)
     return RepoRow(name=name, github=github_info, local=local, agents=repo_agents)
@@ -235,6 +262,10 @@ def run(argv: list[str]) -> int:
         "--refresh", action="store_true",
         help="Rescan disk for clones instead of using the cache.",
     )
+    parser.add_argument(
+        "--llm", action="store_true",
+        help="Summarize each TODO_PLAN.md via `claude` (or `ollama`) for the NEXT column.",
+    )
     args = parser.parse_args(argv)
 
     if not have("gh"):
@@ -247,6 +278,7 @@ def run(argv: list[str]) -> int:
         config,
         fetch_remote_todos=args.fetch_remote_todos,
         refresh_clones=args.refresh,
+        llm=args.llm,
     )
     rows = apply_org_filter(
         rows,

--- a/goldfish/goldfish
+++ b/goldfish/goldfish
@@ -93,9 +93,10 @@ class Progress:
         sys.stderr.flush()
 
     def msg(self, label: str) -> None:
-        if not self.tty:
-            return
-        sys.stderr.write(f"\r\033[K{label}\n")
+        # Always emit informational lines (helpful when stderr is a log file
+        # or test pipe). Only the progress bar is tty-gated.
+        prefix = "\r\033[K" if self.tty else ""
+        sys.stderr.write(f"{prefix}{label}\n")
         sys.stderr.flush()
 
     def done(self) -> None:

--- a/goldfish/shell.py
+++ b/goldfish/shell.py
@@ -16,15 +16,18 @@ from pathlib import Path
 
 from core import (
     AgentSession,
+    ClonesCache,
     GithubInfo,
     LocalInfo,
     GitDirtyState,
     enclosing_repo,
+    parse_clones_cache,
     parse_gh_repo_list,
     parse_git_porcelain,
     parse_lsof_cwd,
     parse_ps,
     parse_todo_plan,
+    serialize_clones_cache,
 )
 
 
@@ -111,6 +114,50 @@ def find_local_clones(roots: list[Path], *, max_depth: int = 6) -> dict[str, Pat
             if name and name not in out:
                 out[name] = workdir
     return out
+
+
+# --- Clones cache (G3) -------------------------------------------------------
+
+CLONES_CACHE_TTL_SECONDS = 24 * 60 * 60
+
+
+def clones_cache_path() -> Path:
+    """Cache file path. Uses $XDG_CACHE_HOME if set, else ~/.cache/."""
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return Path(base) / "goldfish" / "clones.json"
+
+
+def load_cached_clones() -> ClonesCache | None:
+    """Read the cache file. Returns None if missing or malformed."""
+    path = clones_cache_path()
+    if not path.exists():
+        return None
+    try:
+        return parse_clones_cache(path.read_text())
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def save_cached_clones(clones: dict[str, Path]) -> None:
+    """Atomically write the cache file. Errors are silently swallowed."""
+    from datetime import datetime, timezone
+    path = clones_cache_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(".json.tmp")
+        tmp.write_text(serialize_clones_cache(clones, saved_at=datetime.now(timezone.utc)))
+        tmp.replace(path)
+    except OSError:
+        pass
+
+
+def cached_clones_fresh(cache: ClonesCache, *, ttl_seconds: int = CLONES_CACHE_TTL_SECONDS) -> bool:
+    """True if the cache is younger than the TTL and every cached path still has .git/."""
+    from datetime import datetime, timezone
+    age = (datetime.now(timezone.utc) - cache.saved_at).total_seconds()
+    if age > ttl_seconds:
+        return False
+    return all((p / ".git").exists() for p in cache.clones.values())
 
 
 def _find_git_dirs(root: Path, max_depth: int) -> list[Path]:

--- a/goldfish/shell.py
+++ b/goldfish/shell.py
@@ -230,6 +230,36 @@ def running_agents(known: set[str], local_clones: dict[str, Path]) -> list[Agent
     return sessions
 
 
+def all_processes_in_clones(local_clones: dict[str, Path]) -> list[AgentSession]:
+    """Find every running process whose cwd is inside a tracked repo (G6 verbose).
+
+    No name whitelist applied; for catching agents launched through a wrapper
+    (e.g. `python3 launcher.py` re-execing claude) that the agent whitelist
+    would miss.
+    """
+    ps_out = _run(["ps", "-axo", "pid=,comm="], timeout=5.0)
+    if not ps_out:
+        return []
+    repo_paths = set(local_clones.values())
+    sessions: list[AgentSession] = []
+    for line in ps_out.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        parts = line.split(None, 1)
+        if len(parts) != 2 or not parts[0].isdigit():
+            continue
+        pid = int(parts[0])
+        name = parts[1].rsplit("/", 1)[-1]
+        cwd = _proc_cwd(pid)
+        if cwd is None:
+            continue
+        repo = enclosing_repo(cwd, repo_paths)
+        if repo is not None:
+            sessions.append(AgentSession(pid=pid, name=name, repo_path=repo))
+    return sessions
+
+
 def _proc_cwd(pid: int) -> Path | None:
     """Return process cwd. Linux uses /proc, macOS/BSD uses lsof."""
     if platform.system() == "Linux":

--- a/goldfish/shell.py
+++ b/goldfish/shell.py
@@ -21,6 +21,7 @@ from core import (
     LocalInfo,
     GitDirtyState,
     enclosing_repo,
+    first_meaningful_line,
     parse_clones_cache,
     parse_gh_repo_list,
     parse_git_porcelain,
@@ -243,6 +244,46 @@ def _parse_iso_safe(raw: str) -> datetime | None:
         return datetime.fromisoformat(raw)
     except ValueError:
         return None
+
+
+# --- LLM next-task summarizer (G2) -------------------------------------------
+
+LLM_PROMPT = (
+    "Read the TODO_PLAN.md content on stdin. In one short sentence "
+    "(<= 100 chars), describe the single next concrete task. No preamble, "
+    "no quotes, no markdown, just the sentence."
+)
+
+
+def summarize_with_llm(todo_text: str, *, timeout: float = 30.0) -> str | None:
+    """Summarize a TODO_PLAN via claude or ollama. Returns None if both fail.
+
+    Tries `claude -p` first, then `ollama run llama3.2` as a fallback. Both
+    accept the file content on stdin.
+    """
+    if not todo_text.strip():
+        return None
+    for cmd in _llm_candidates():
+        try:
+            result = subprocess.run(
+                cmd, input=todo_text, capture_output=True, text=True,
+                timeout=timeout, check=False,
+            )
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            continue
+        if result.returncode == 0 and result.stdout.strip():
+            return first_meaningful_line(result.stdout)
+    return None
+
+
+def _llm_candidates() -> list[list[str]]:
+    out: list[list[str]] = []
+    if have("claude"):
+        out.append(["claude", "-p", LLM_PROMPT])
+    if have("ollama"):
+        model = os.environ.get("GOLDFISH_OLLAMA_MODEL", "llama3.2")
+        out.append(["ollama", "run", model, LLM_PROMPT])
+    return out
 
 
 def fetch_remote_todo_plan(name_with_owner: str) -> str | None:

--- a/goldfish/test_core.py
+++ b/goldfish/test_core.py
@@ -13,6 +13,7 @@ from core import (
     GithubInfo,
     LocalInfo,
     RepoRow,
+    apply_org_filter,
     enclosing_repo,
     format_table,
     latest_activity,
@@ -21,6 +22,7 @@ from core import (
     parse_lsof_cwd,
     parse_ps,
     parse_todo_plan,
+    rows_to_json,
     sort_rows,
 )
 
@@ -319,6 +321,87 @@ def test_format_table_agents_listed() -> None:
     table = format_table(rows)
     line = [l for l in table.splitlines() if "todd/foo" in l][0]
     assert "claude" in line and "codex" in line
+
+
+# --- apply_org_filter (G7) ---------------------------------------------------
+
+def _row(name: str) -> RepoRow:
+    return RepoRow(name=name, github=None, local=None, agents=())
+
+
+def test_apply_org_filter_no_filters_passes_everything() -> None:
+    """Given no include/exclude, every row survives."""
+    rows = [_row("a/x"), _row("b/y")]
+    out = apply_org_filter(rows, include=(), exclude=())
+    assert [r.name for r in out] == ["a/x", "b/y"]
+
+
+def test_apply_org_filter_include_keeps_only_listed_orgs() -> None:
+    """Given include=('a',), rows whose owner is 'a' survive; others drop."""
+    rows = [_row("a/x"), _row("b/y"), _row("a/z")]
+    out = apply_org_filter(rows, include=("a",), exclude=())
+    assert sorted(r.name for r in out) == ["a/x", "a/z"]
+
+
+def test_apply_org_filter_exclude_drops_listed_orgs() -> None:
+    """Given exclude=('b',), rows whose owner is 'b' drop; others survive."""
+    rows = [_row("a/x"), _row("b/y"), _row("c/z")]
+    out = apply_org_filter(rows, include=(), exclude=("b",))
+    assert sorted(r.name for r in out) == ["a/x", "c/z"]
+
+
+def test_apply_org_filter_exclude_wins_over_include() -> None:
+    """Given a/x in both include and exclude, exclude wins."""
+    rows = [_row("a/x"), _row("a/y")]
+    out = apply_org_filter(rows, include=("a",), exclude=("a",))
+    assert out == []
+
+
+def test_apply_org_filter_handles_unowned_names() -> None:
+    """Given a row with no owner/ prefix (malformed), include filter rejects it."""
+    rows = [_row("noowner")]
+    out = apply_org_filter(rows, include=("a",), exclude=())
+    assert out == []
+
+
+# --- rows_to_json (G5) -------------------------------------------------------
+
+def test_rows_to_json_emits_valid_json() -> None:
+    """Given any rows, output parses as JSON."""
+    import json
+    rows = [_row("a/x")]
+    parsed = json.loads(rows_to_json(rows))
+    assert isinstance(parsed, list) and parsed[0]["name"] == "a/x"
+
+
+def test_rows_to_json_serializes_all_fields() -> None:
+    """Given a fully-populated row, JSON contains every column."""
+    import json
+    row = RepoRow(
+        name="a/x",
+        github=GithubInfo(name="a/x", pushed_at=_utc(2026, 4, 1), open_pr_count=2),
+        local=LocalInfo(
+            path=Path("/x"), is_dirty=True, ahead=3, behind=1,
+            branch="main", last_commit_at=_utc(2026, 4, 20),
+            next_task="do the thing",
+        ),
+        agents=(AgentSession(pid=1, name="claude", repo_path=Path("/x")),),
+    )
+    parsed = json.loads(rows_to_json([row]))
+    entry = parsed[0]
+    assert entry["github"]["open_pr_count"] == 2
+    assert entry["local"]["is_dirty"] is True
+    assert entry["local"]["next_task"] == "do the thing"
+    assert entry["agents"][0]["name"] == "claude"
+
+
+def test_rows_to_json_handles_missing_github_and_local() -> None:
+    """Given a row with no github or local info, those fields are null."""
+    import json
+    parsed = json.loads(rows_to_json([_row("a/x")]))
+    assert parsed[0]["github"] is None
+    assert parsed[0]["local"] is None
+    assert parsed[0]["agents"] == []
 
 
 def test_format_table_next_task_truncated() -> None:

--- a/goldfish/test_core.py
+++ b/goldfish/test_core.py
@@ -18,12 +18,14 @@ from core import (
     format_processes,
     format_table,
     latest_activity,
+    parse_clones_cache,
     parse_git_porcelain,
     parse_gh_repo_list,
     parse_lsof_cwd,
     parse_ps,
     parse_todo_plan,
     rows_to_json,
+    serialize_clones_cache,
     sort_rows,
 )
 
@@ -322,6 +324,35 @@ def test_format_table_agents_listed() -> None:
     table = format_table(rows)
     line = [l for l in table.splitlines() if "todd/foo" in l][0]
     assert "claude" in line and "codex" in line
+
+
+# --- clones cache (G3) -------------------------------------------------------
+
+def test_serialize_clones_cache_round_trips() -> None:
+    """Given a clones map, serialize then parse returns the same map."""
+    clones = {"a/x": Path("/r/a/x"), "b/y": Path("/r/b/y")}
+    text = serialize_clones_cache(clones, saved_at=_utc(2026, 4, 28))
+    cache = parse_clones_cache(text)
+    assert cache.clones == clones
+    assert cache.saved_at == _utc(2026, 4, 28)
+
+
+def test_parse_clones_cache_handles_unknown_version_gracefully() -> None:
+    """Given a future-version cache file, returns None instead of raising."""
+    bad = '{"version": 99, "clones": {"a/x": "/r/a/x"}}'
+    assert parse_clones_cache(bad) is None
+
+
+def test_parse_clones_cache_handles_garbage() -> None:
+    """Given non-JSON input, returns None instead of raising."""
+    assert parse_clones_cache("not json at all") is None
+
+
+def test_parse_clones_cache_empty_clones_map() -> None:
+    """Given a valid cache with no clones, returns an empty map."""
+    text = serialize_clones_cache({}, saved_at=_utc(2026, 4, 1))
+    cache = parse_clones_cache(text)
+    assert cache.clones == {}
 
 
 # --- format_processes (G6) ---------------------------------------------------

--- a/goldfish/test_core.py
+++ b/goldfish/test_core.py
@@ -15,6 +15,7 @@ from core import (
     RepoRow,
     apply_org_filter,
     enclosing_repo,
+    first_meaningful_line,
     format_processes,
     format_table,
     latest_activity,
@@ -324,6 +325,33 @@ def test_format_table_agents_listed() -> None:
     table = format_table(rows)
     line = [l for l in table.splitlines() if "todd/foo" in l][0]
     assert "claude" in line and "codex" in line
+
+
+# --- first_meaningful_line (G2) ----------------------------------------------
+
+def test_first_meaningful_line_returns_first_nonempty() -> None:
+    """Given output with leading blank lines, returns the first non-empty line."""
+    raw = "\n\n  \nactual content here\nignored\n"
+    assert first_meaningful_line(raw) == "actual content here"
+
+
+def test_first_meaningful_line_strips_quotes_and_bullets() -> None:
+    """Given LLM-style output with quotes / bullets, those are stripped."""
+    assert first_meaningful_line('"Wire up retry on 429"') == "Wire up retry on 429"
+    assert first_meaningful_line("- Wire up retry") == "Wire up retry"
+    assert first_meaningful_line("* Wire up retry") == "Wire up retry"
+
+
+def test_first_meaningful_line_empty_input_returns_none() -> None:
+    """Given empty/whitespace input, returns None."""
+    assert first_meaningful_line("") is None
+    assert first_meaningful_line("   \n\n") is None
+
+
+def test_first_meaningful_line_truncates_long_output() -> None:
+    """Given a long line, output is bounded so it fits the table column."""
+    long = "x" * 500
+    assert len(first_meaningful_line(long)) <= 200
 
 
 # --- clones cache (G3) -------------------------------------------------------

--- a/goldfish/test_core.py
+++ b/goldfish/test_core.py
@@ -15,6 +15,7 @@ from core import (
     RepoRow,
     apply_org_filter,
     enclosing_repo,
+    format_processes,
     format_table,
     latest_activity,
     parse_git_porcelain,
@@ -321,6 +322,35 @@ def test_format_table_agents_listed() -> None:
     table = format_table(rows)
     line = [l for l in table.splitlines() if "todd/foo" in l][0]
     assert "claude" in line and "codex" in line
+
+
+# --- format_processes (G6) ---------------------------------------------------
+
+def test_format_processes_empty_list_returns_empty_string() -> None:
+    """Given no sessions, returns empty string (no header)."""
+    assert format_processes([]) == ""
+
+
+def test_format_processes_groups_by_repo() -> None:
+    """Given sessions across two repos, output groups them under each repo path."""
+    sessions = [
+        AgentSession(pid=1, name="claude", repo_path=Path("/r/a")),
+        AgentSession(pid=2, name="vim", repo_path=Path("/r/b")),
+        AgentSession(pid=3, name="bash", repo_path=Path("/r/a")),
+    ]
+    out = format_processes(sessions)
+    assert "/r/a" in out and "/r/b" in out
+    a_block_start = out.index("/r/a")
+    b_block_start = out.index("/r/b")
+    a_block = out[a_block_start:b_block_start] if a_block_start < b_block_start else out[a_block_start:]
+    assert "claude" in a_block and "bash" in a_block
+
+
+def test_format_processes_includes_pid_and_name() -> None:
+    """Given a session, both pid and name appear in the output."""
+    sessions = [AgentSession(pid=4242, name="codex", repo_path=Path("/r/x"))]
+    out = format_processes(sessions)
+    assert "4242" in out and "codex" in out
 
 
 # --- apply_org_filter (G7) ---------------------------------------------------

--- a/test/smoketest_goldfish/01_local_clone_appears.sh
+++ b/test/smoketest_goldfish/01_local_clone_appears.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# 01_local_clone_appears.sh — a fake clone with a github remote shows up in the table.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    make_fake_clone "todd/foo" >/dev/null
+    out="$(run_goldfish 2>/dev/null)"
+    if ! grep -q "todd/foo" <<<"${out}"; then
+        echo "FAIL: todd/foo not in output:"
+        echo "${out}"
+        return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_goldfish/02_dirty_repo_marker.sh
+++ b/test/smoketest_goldfish/02_dirty_repo_marker.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# 02_dirty_repo_marker.sh — a clone with uncommitted changes shows the dirty marker.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    dir="$(make_fake_clone "todd/dirty")"
+    echo "untracked" > "${dir}/new_file.txt"
+    out="$(run_goldfish 2>/dev/null)"
+    line="$(grep "todd/dirty" <<<"${out}" || true)"
+    if [[ -z "${line}" ]]; then
+        echo "FAIL: todd/dirty not in output"
+        echo "${out}"
+        return 1
+    fi
+    if ! grep -q "\*" <<<"${line}"; then
+        echo "FAIL: dirty marker '*' missing from row:"
+        echo "${line}"
+        return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_goldfish/03_todo_plan_next_task.sh
+++ b/test/smoketest_goldfish/03_todo_plan_next_task.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# 03_todo_plan_next_task.sh — first unchecked TODO_PLAN line surfaces in NEXT.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    todo=$'# Plan\n- [x] done\n- [ ] write the next big thing\n- [ ] another'
+    make_fake_clone "todd/planner" "${todo}" >/dev/null
+    out="$(run_goldfish 2>/dev/null)"
+    if ! grep -q "write the next big thing" <<<"${out}"; then
+        echo "FAIL: next-task line not surfaced. Output was:"
+        echo "${out}"
+        return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_goldfish/04_json_output.sh
+++ b/test/smoketest_goldfish/04_json_output.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# 04_json_output.sh — --json emits a parseable JSON array (G5).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    make_fake_clone "todd/json" >/dev/null
+    out="$(run_goldfish --json 2>/dev/null)"
+    # Must parse as JSON.
+    if ! python3 -c "import json,sys; json.loads(sys.stdin.read())" <<<"${out}" 2>/dev/null; then
+        echo "FAIL: --json output is not valid JSON:"
+        echo "${out}"
+        return 1
+    fi
+    # Must contain the repo name.
+    if ! python3 -c "
+import json, sys
+data = json.loads(sys.stdin.read())
+names = [r['name'] for r in data]
+sys.exit(0 if 'todd/json' in names else 1)
+" <<<"${out}"; then
+        echo "FAIL: todd/json missing from JSON output:"
+        echo "${out}"
+        return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_goldfish/05_clone_cache.sh
+++ b/test/smoketest_goldfish/05_clone_cache.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# 05_clone_cache.sh — first run writes the cache, second run uses it (G3).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    make_fake_clone "todd/cached" >/dev/null
+    rm -rf "${SMOKE_CACHE}"
+    run_goldfish >/dev/null 2>&1
+    cache_file="${SMOKE_CACHE}/goldfish/clones.json"
+    if [[ ! -f "${cache_file}" ]]; then
+        echo "FAIL: cache file not written at ${cache_file}"
+        return 1
+    fi
+    if ! grep -q "todd/cached" "${cache_file}"; then
+        echo "FAIL: cache does not contain todd/cached:"
+        cat "${cache_file}"
+        return 1
+    fi
+    # Second run with cache present should still surface the repo.
+    out="$(run_goldfish 2>&1)"
+    if ! grep -q "todd/cached" <<<"${out}"; then
+        echo "FAIL: cached run did not surface todd/cached:"
+        echo "${out}"
+        return 1
+    fi
+    if ! grep -q "using cached clones" <<<"${out}"; then
+        echo "FAIL: stderr did not announce cache hit:"
+        echo "${out}"
+        return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_goldfish/06_org_filter.sh
+++ b/test/smoketest_goldfish/06_org_filter.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# 06_org_filter.sh — --exclude-org hides matching repos (G7).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    make_fake_clone "alpha/keep" >/dev/null
+    make_fake_clone "beta/drop" >/dev/null
+    out="$(run_goldfish --exclude-org beta --refresh 2>/dev/null)"
+    if ! grep -q "alpha/keep" <<<"${out}"; then
+        echo "FAIL: alpha/keep should be visible:"
+        echo "${out}"
+        return 1
+    fi
+    if grep -q "beta/drop" <<<"${out}"; then
+        echo "FAIL: beta/drop should be hidden by --exclude-org beta:"
+        echo "${out}"
+        return 1
+    fi
+    # Now check --include-org alpha keeps only alpha.
+    out="$(run_goldfish --include-org alpha --refresh 2>/dev/null)"
+    if ! grep -q "alpha/keep" <<<"${out}"; then
+        echo "FAIL: alpha/keep should be visible with --include-org alpha:"
+        echo "${out}"
+        return 1
+    fi
+    if grep -q "beta/drop" <<<"${out}"; then
+        echo "FAIL: beta/drop should be hidden by --include-org alpha:"
+        echo "${out}"
+        return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_goldfish/config.sh
+++ b/test/smoketest_goldfish/config.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# config.sh — shared environment for goldfish smoke tests
+# config.sh — shared environment + helpers for goldfish smoke tests
 #
-# Sourced by run_all.sh (which sets up SMOKE_TMP and SMOKE_CONFIG) and by
-# every scenario script. SMOKE_TMP is an isolated tmp tree; SMOKE_CONFIG is
-# a goldfish config.json pointing at $SMOKE_TMP/clones as the only root.
+# Defines `init_smoke_env` (called once by run_all.sh after SMOKE_TMP is
+# allocated) plus `run_goldfish` and `make_fake_clone` (called by every
+# scenario). Sourcing this file is side-effect-free; init_smoke_env is the
+# single mutator and writes ${SMOKE_CONFIG} based on ${SMOKE_TMP}.
 
 set -euo pipefail
 
@@ -11,30 +12,31 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 GOLDFISH="${REPO_DIR}/goldfish/goldfish"
 
-if [[ -z "${SMOKE_TMP:-}" ]]; then
-    echo "error: SMOKE_TMP must be set by run_all.sh before sourcing config.sh" >&2
-    exit 1
-fi
+# --- Init --------------------------------------------------------------------
 
-export SMOKE_CLONES="${SMOKE_TMP}/clones"
-export SMOKE_CACHE="${SMOKE_TMP}/cache"
-export SMOKE_CONFIG="${SMOKE_TMP}/config.json"
+init_smoke_env() {
+    if [[ -z "${SMOKE_TMP:-}" ]]; then
+        echo "error: SMOKE_TMP must be set before init_smoke_env" >&2
+        return 1
+    fi
+    export SMOKE_CLONES="${SMOKE_TMP}/clones"
+    export SMOKE_CACHE="${SMOKE_TMP}/cache"
+    export SMOKE_CONFIG="${SMOKE_TMP}/config.json"
 
-# Build a goldfish config pointing only at our tmp clones dir.
-cat > "${SMOKE_CONFIG}" <<EOF
+    cat > "${SMOKE_CONFIG}" <<EOF
 {
     "orgs": [],
     "agents": ["claude", "gemini", "opencode", "codex"],
     "roots": ["${SMOKE_CLONES}"]
 }
 EOF
+}
+
+# --- Action helpers ----------------------------------------------------------
 
 # Run goldfish with the smoke config swapped in. Each scenario calls
 # `run_goldfish [args...]` to invoke against the isolated environment.
 run_goldfish() {
-    # goldfish reads config from goldfish/config.json next to the script;
-    # to override hermetically without touching the real file, copy
-    # goldfish/ into SMOKE_TMP, drop our config in, and run from there.
     if [[ ! -d "${SMOKE_TMP}/goldfish" ]]; then
         cp -r "${REPO_DIR}/goldfish" "${SMOKE_TMP}/goldfish"
         cp "${SMOKE_CONFIG}" "${SMOKE_TMP}/goldfish/config.json"
@@ -59,7 +61,7 @@ make_fake_clone() {
         git remote add origin "git@github.com:${nameowner}.git"
         echo "x" > a.txt
         git add a.txt
-        git commit -qm "first" 2>/dev/null || true
+        git commit -qm "first"
         if [[ -n "${todo}" ]]; then
             printf '%s\n' "${todo}" > TODO_PLAN.md
         fi
@@ -69,4 +71,4 @@ make_fake_clone() {
     echo "${dir}"
 }
 
-export -f run_goldfish make_fake_clone
+export -f run_goldfish make_fake_clone init_smoke_env

--- a/test/smoketest_goldfish/config.sh
+++ b/test/smoketest_goldfish/config.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# config.sh — shared environment for goldfish smoke tests
+#
+# Sourced by run_all.sh (which sets up SMOKE_TMP and SMOKE_CONFIG) and by
+# every scenario script. SMOKE_TMP is an isolated tmp tree; SMOKE_CONFIG is
+# a goldfish config.json pointing at $SMOKE_TMP/clones as the only root.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+GOLDFISH="${REPO_DIR}/goldfish/goldfish"
+
+if [[ -z "${SMOKE_TMP:-}" ]]; then
+    echo "error: SMOKE_TMP must be set by run_all.sh before sourcing config.sh" >&2
+    exit 1
+fi
+
+export SMOKE_CLONES="${SMOKE_TMP}/clones"
+export SMOKE_CACHE="${SMOKE_TMP}/cache"
+export SMOKE_CONFIG="${SMOKE_TMP}/config.json"
+
+# Build a goldfish config pointing only at our tmp clones dir.
+cat > "${SMOKE_CONFIG}" <<EOF
+{
+    "orgs": [],
+    "agents": ["claude", "gemini", "opencode", "codex"],
+    "roots": ["${SMOKE_CLONES}"]
+}
+EOF
+
+# Run goldfish with the smoke config swapped in. Each scenario calls
+# `run_goldfish [args...]` to invoke against the isolated environment.
+run_goldfish() {
+    # goldfish reads config from goldfish/config.json next to the script;
+    # to override hermetically without touching the real file, copy
+    # goldfish/ into SMOKE_TMP, drop our config in, and run from there.
+    if [[ ! -d "${SMOKE_TMP}/goldfish" ]]; then
+        cp -r "${REPO_DIR}/goldfish" "${SMOKE_TMP}/goldfish"
+        cp "${SMOKE_CONFIG}" "${SMOKE_TMP}/goldfish/config.json"
+    fi
+    XDG_CACHE_HOME="${SMOKE_CACHE}" \
+        python3 "${SMOKE_TMP}/goldfish/goldfish" "$@"
+}
+
+# Initialize a fake clone with a github remote inside SMOKE_CLONES.
+# Usage: make_fake_clone <owner/repo> [todo_plan_content]
+make_fake_clone() {
+    local nameowner="$1"
+    local todo="${2:-}"
+    local dir="${SMOKE_CLONES}/$(basename "${nameowner}")"
+    mkdir -p "${dir}"
+    (
+        cd "${dir}"
+        git init -q
+        git config user.email "test@example.com"
+        git config user.name "test"
+        git config commit.gpgsign false
+        git remote add origin "git@github.com:${nameowner}.git"
+        echo "x" > a.txt
+        git add a.txt
+        git commit -qm "first" 2>/dev/null || true
+        if [[ -n "${todo}" ]]; then
+            printf '%s\n' "${todo}" > TODO_PLAN.md
+        fi
+    )
+    # Invalidate the clones cache so the new repo is picked up on the next run.
+    rm -f "${SMOKE_CACHE}/goldfish/clones.json"
+    echo "${dir}"
+}
+
+export -f run_goldfish make_fake_clone

--- a/test/smoketest_goldfish/run_all.sh
+++ b/test/smoketest_goldfish/run_all.sh
@@ -10,17 +10,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-if ! command -v git >/dev/null 2>&1; then
-    echo "skip: git not on PATH"
-    exit 0
-fi
-
-export SMOKE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/goldfish-smoke.XXXXXX")"
-trap 'rm -rf "${SMOKE_TMP}"' EXIT
-
-source "${SCRIPT_DIR}/config.sh"
-
-# --- Test harness ---
+# --- Test harness (definitions; control flow lives in main) ------------------
 
 TESTS_RUN=0
 TESTS_PASSED=0
@@ -45,7 +35,22 @@ run_test() {
     fi
 }
 
+# --- Main --------------------------------------------------------------------
+
 main() {
+    if ! command -v git >/dev/null 2>&1; then
+        echo "skip: git not on PATH"
+        return 0
+    fi
+
+    export SMOKE_TMP
+    SMOKE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/goldfish-smoke.XXXXXX")"
+    trap 'rm -rf "${SMOKE_TMP}"' EXIT
+
+    # shellcheck source=./config.sh
+    source "${SCRIPT_DIR}/config.sh"
+    init_smoke_env
+
     printf "goldfish smoke tests (tmp=%s)\n" "${SMOKE_TMP}"
     for script in "${SCRIPT_DIR}"/[0-9][0-9]_*.sh; do
         [[ -f "${script}" ]] || continue

--- a/test/smoketest_goldfish/run_all.sh
+++ b/test/smoketest_goldfish/run_all.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# run_all.sh — orchestrate goldfish smoke tests
+#
+# Hermetic: every scenario runs against a fresh tmpdir of fake repos. No
+# network. No real $HOME walk. Skips gracefully if `git` is unavailable.
+#
+# Usage: ./test/smoketest_goldfish/run_all.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if ! command -v git >/dev/null 2>&1; then
+    echo "skip: git not on PATH"
+    exit 0
+fi
+
+export SMOKE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/goldfish-smoke.XXXXXX")"
+trap 'rm -rf "${SMOKE_TMP}"' EXIT
+
+source "${SCRIPT_DIR}/config.sh"
+
+# --- Test harness ---
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+red()   { printf "\033[1;31m%s\033[0m" "$1"; }
+green() { printf "\033[1;32m%s\033[0m" "$1"; }
+bold()  { printf "\033[1m%s\033[0m" "$1"; }
+
+run_test() {
+    local script="$1"
+    local name
+    name="$(basename "${script}" .sh)"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    printf "  %s ... " "$(bold "${name}")"
+    if ( bash "${script}" ); then
+        printf "%s\n" "$(green PASS)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf "%s\n" "$(red FAIL)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+main() {
+    printf "goldfish smoke tests (tmp=%s)\n" "${SMOKE_TMP}"
+    for script in "${SCRIPT_DIR}"/[0-9][0-9]_*.sh; do
+        [[ -f "${script}" ]] || continue
+        run_test "${script}"
+    done
+    printf "\n%d run, %d passed, %d failed\n" \
+        "${TESTS_RUN}" "${TESTS_PASSED}" "${TESTS_FAILED}"
+    [[ "${TESTS_FAILED}" -eq 0 ]]
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Lands the goldfish post-MVP follow-ups from `TODO_PLAN.md` (G2, G3, G5, G6, G7) plus a hermetic smoke-test suite (G4). G8 (`bin/goldfish` symlink) intentionally deferred per its TODO_PLAN note ("optional, once layout settles").

Each task is a separate commit so review can be done piecewise. 52/52 unit tests green. 6/6 smoke tests green on Linux.

### Per-commit breakdown

| SHA | Task | What |
|-----|------|------|
| `e6a2467` | **G5 + G7** | `--json` output mode, `--include-org` / `--exclude-org` flags. New pure helpers `apply_org_filter` and `rows_to_json`. |
| `cf0fef8` | **G6** | `-v` / `--verbose` lists every process whose cwd is in a tracked repo, not just the agent whitelist. Catches wrapper-launched agents. |
| `4a17766` | **G3** | Cache clone discovery to `$XDG_CACHE_HOME/goldfish/clones.json` (24h TTL + path-existence check). `--refresh` flag forces rescan. |
| `202efb0` | **G2** | `--llm` summarizes each TODO_PLAN.md via `claude -p` (preferred) or `ollama run` (fallback). Runs inside the existing per-row `ThreadPoolExecutor`; pure `first_meaningful_line` helper trims chatty output. |
| `90c2811` | **G4** | `test/smoketest_goldfish/` — hermetic bash suite, 6 scenarios. Also fixes `Progress.msg` to always write to stderr (was tty-only — fine for humans, useless in CI/logs). |

### Bug caught by the smoke tests

While writing G4 the cache scenario surfaced two real problems and both are fixed in `90c2811`:

1. The `Progress.msg` "using cached clones" line never reached stderr in non-tty contexts. Now it does (the `\r` prefix is still tty-only so the progress bar still looks right interactively).
2. Within a smoke run, scenarios that added a new clone didn't see it because the cache from a previous scenario shadowed it. `make_fake_clone` now invalidates the cache as part of setup — exactly the workflow a real user adding a clone would follow with `--refresh`.

## Test plan

- [x] `pytest goldfish/test_core.py` — 52/52 green (was 33 before this PR; +19 new pure tests).
- [x] `test/smoketest_goldfish/run_all.sh` — 6/6 green on Linux.
- [ ] macOS smoke run — sandbox is Linux-only; G4's TODO entry stays open until run on a real macOS box.
- [ ] Manual sanity once landed: `goldfish --llm` against a real repo with `claude` on `$PATH`.

https://claude.ai/code/session_011kLYTYDvCsyFoZ6w2wapEw

---
_Generated by [Claude Code](https://claude.ai/code/session_011kLYTYDvCsyFoZ6w2wapEw)_