### PR TITLE
feat(log-hoarder): meaningful tmux titles + window labels

### DIFF
--- a/TODO_PLAN.md
+++ b/TODO_PLAN.md
@@ -36,7 +36,6 @@ This file tracks the status of development tasks, lessons learned, and completed
 
 ### log-hoarder / tmux UX
 
-- [ ] Task L1: **Bring joy to the human via the tmux status bar and outer terminal title** — replace defaults like `0:claude.exe` and `Terminal — tmux new-session — 121x35` with session, cwd, and command context.
 - [ ] Task L2: **Adopt meaningful session names** — default numeric (`18`, `19`, `20`…) make `tmux ls` and the new title-string both worse than they need to be.
 - [ ] Task L3: **Handle session-rename → log-path drift** — `tmux_logging.sh` bakes `#S` at pipe-pane time, so renaming a live session splits its logs across old and new dirs.
 
@@ -105,4 +104,5 @@ This file tracks the status of development tasks, lessons learned, and completed
 - [x] Task 2 (Scaffolding): Implement domain models, ports, `TxtaiAdapter`, indexer, and searcher.
 - [x] Task 2 (Design revision): Refine design with span/chunk model — spans as semantic segments, chunks as embedding units, search groups by span.
 - [x] Task 2a: Implement `Span` and `Chunk` domain models in `search/domain/models.py`. Added frozen dataclasses with validation, `Chunk.from_span()` factory, `index_key` property. 21 unit tests + 9 smoke tests against real session data. Also added `pyproject.toml` for log-hoarder and `__pycache__` to `.gitignore`. PR #10.
+- [x] Task L1: Bring joy to the human via the tmux status bar and outer terminal title — `tmux[<session>] <i>/<n> -- <pwd>/<cmd>` in the macOS title bar; `<idx>:<pwd>/<cmd><flag>` in the per-window status-bar labels. PR #19.
 - [x] Task G1: Build `goldfish/` v1 -- at-a-glance recent-work report across GitHub repos and local clones. Hexagonal split: pure `core.py` (parsers, formatters, sort) with 33 unit tests, plus `shell.py` adapters wrapping `gh`/`git`/`ps`/`lsof`/`find`. Entry script fans probes across a `ThreadPoolExecutor` and renders a stderr progress bar. Hardcoded MVP config in `goldfish/config.json` (orgs allow-list, agent process whitelist, on-disk roots). PR #15.

--- a/TODO_PLAN.md
+++ b/TODO_PLAN.md
@@ -34,6 +34,12 @@ This file tracks the status of development tasks, lessons learned, and completed
 
 - [x] Task Z1: Create ZLE widget for `ctrl-x s` — invokes `log_search`, pipes results through `fzf` for selection, displays matched log section in `$PAGER`. Plugin file `macos/dot.zsh_log_search`, sourced from `dot.zshrc`. PR #12.
 
+### log-hoarder / tmux UX
+
+- [ ] Task L1: **Bring joy to the human via the tmux status bar and outer terminal title** — replace defaults like `0:claude.exe` and `Terminal — tmux new-session — 121x35` with session, cwd, and command context.
+- [ ] Task L2: **Adopt meaningful session names** — default numeric (`18`, `19`, `20`…) make `tmux ls` and the new title-string both worse than they need to be.
+- [ ] Task L3: **Handle session-rename → log-path drift** — `tmux_logging.sh` bakes `#S` at pipe-pane time, so renaming a live session splits its logs across old and new dirs.
+
 ### goldfish (post-MVP follow-ups)
 
 - [ ] Task G2: **LLM-summarized "next task" column.** Currently goldfish prints

--- a/log-hoarder/tmux.conf
+++ b/log-hoarder/tmux.conf
@@ -15,12 +15,13 @@ set -g mode-keys emacs
 # --- Outer terminal title ---
 # Push a meaningful title into the host terminal (Terminal.app, iTerm2, etc.)
 # whenever the active pane changes (session/window/pane switch).
-# Format: "session window-index/window-count · window-name · pwd-basename"
+# Format: "tmux[session] window-index/window-count -- pwd-basename/window-name"
+# macOS Terminal.app appends "Dimensions" (e.g. "-- 121x35") if enabled.
 # Note (macOS Terminal.app): uncheck "Active Process Name" in
-# Preferences → Profiles → Window → Title, or this string gets prepended
-# with "tmux new-session" noise. "Dimensions" can stay on.
+# Preferences → Profiles → Window → Title, or this string gets followed
+# by "tmux new-session" noise.
 set -g set-titles on
-set -g set-titles-string '#S #I/#{session_windows} · #W · #{b:pane_current_path}'
+set -g set-titles-string 'tmux[#S] #I/#{session_windows} -- #{b:pane_current_path}/#W'
 
 # --- Window-list labels in status bar ---
 # Default '#I:#W#F' shows just index + window-name (which under auto-rename

--- a/log-hoarder/tmux.conf
+++ b/log-hoarder/tmux.conf
@@ -12,6 +12,26 @@
 set -g mouse on
 set -g mode-keys emacs
 
+# --- Outer terminal title ---
+# Push a meaningful title into the host terminal (Terminal.app, iTerm2, etc.)
+# whenever the active pane changes (session/window/pane switch).
+# Format: "session window-index/window-count · window-name · pwd-basename"
+# Note (macOS Terminal.app): uncheck "Active Process Name" in
+# Preferences → Profiles → Window → Title, or this string gets prepended
+# with "tmux new-session" noise. "Dimensions" can stay on.
+set -g set-titles on
+set -g set-titles-string '#S #I/#{session_windows} · #W · #{b:pane_current_path}'
+
+# --- Window-list labels in status bar ---
+# Default '#I:#W#F' shows just index + window-name (which under auto-rename
+# is the current command), giving useless lists like
+# "0:claude.exe 1:claude.exe 2:claude.exe". Add cwd basename so each window
+# label tells you what project it's in.
+# #I = index, #{b:pane_current_path} = pwd basename, #W = window name (auto = cmd),
+# #F = flags (* current, - last, Z zoomed, etc.).
+set -g window-status-format         '#I:#{b:pane_current_path}/#W#F'
+set -g window-status-current-format '#I:#{b:pane_current_path}/#W#F'
+
 # Don't exit copy mode when scrolling to the bottom of the pane.
 # Default uses copy-mode -e which auto-exits, killing any active selection.
 bind -T root WheelUpPane if-shell -F "#{||:#{alternate_on},#{pane_in_mode},#{mouse_any_flag}}" { send-keys -M } { copy-mode }


### PR DESCRIPTION
## Summary

- Outer terminal title gets a `tmux[<session>] <idx>/<count> -- <pwd>/<cmd>` framing — replaces the default `tmux new-session — 121x35` non-signal so any terminal window's purpose is legible at a glance.
- tmux's status-bar window list flips from `0:claude.exe 1:claude.exe 2:claude.exe` to `0:tds-utils/claude.exe 1:airframe/claude.exe …` so per-window cwd is visible without flipping in.
- Adds a `log-hoarder / tmux UX` section to `TODO_PLAN.md` with three follow-ups: meaningful session names (default `0/1/2/…` is still useless), and the session-rename → log-path drift in `tmux_logging.sh` that the new naming will surface.

Manual one-time setup for macOS Terminal users: Terminal.app → Preferences → Profiles → *your profile* → Window → Title → uncheck **Active Process Name**. Otherwise our title gets followed by `tmux new-session` noise. Documented in the tmux.conf comment.

## Test plan

- [ ] `tmux source-file ~/.tmux.conf` reloads cleanly with no errors.
- [ ] Outer Terminal title reads `tmux[<session>] <i>/<n> -- <pwd>/<cmd> -- <dims>` and updates on session/window/pane switch.
- [ ] Status-bar window list shows `<idx>:<pwd>/<cmd><flag>` for every window in the current session.
- [ ] Existing log-hoarder hooks (`session-created`, `after-new-window`, `after-split-window`, `pane-exited`) still fire — new pane creates a log under `$TDS_LOG_DIR/active/...`.
- [ ] Mouse copy-mode bindings (seesaw, double/triple-click, M-w, right-click) still behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)