### PR TITLE
feat(clai): CLI AI launcher with overlay hooks

### DIFF
--- a/CLAI.DESIGN.md
+++ b/CLAI.DESIGN.md
@@ -1,0 +1,102 @@
+# clai — CLI AI launcher with overlay hooks
+
+## Purpose
+
+Thin wrapper around interactive AI CLI agents (`claude`, `gemini`, `codex`, …)
+that runs pre- and post-hooks discovered from a directory walk. Born to solve:
+"keep Cloudflare MCPs defined globally but disabled by default for new
+projects" — but the hook framework is general.
+
+## Invocation
+
+```
+clai <agent> [args...]
+```
+
+Runs all pre-hooks for `<agent>`, then `exec`s `<agent> [args...]`. Post-hooks
+fire after the agent exits.
+
+## Hook discovery — overlay walk
+
+Walk from `$PWD` upward to `$HOME` **inclusive**. At each directory level, if
+`clai.d/<agent>/<stage>/` exists, its contents contribute to the hook set for
+that stage.
+
+Stages: `pre`, `post`.
+
+**Stop condition:** the walk halts at `$HOME`. If `$PWD` is not within `$HOME`
+(e.g. `/tmp`), only `~/clai.d/` is consulted — never walk above `$HOME`, never
+walk paths outside it.
+
+**Merge semantics — override-by-filename:**
+- Same basename at multiple levels → closer-to-`$PWD` wins.
+- A zero-byte file at a closer level nulls out a deeper hook of that name (you
+  can shadow a global hook to disable it in one project).
+
+**Run order:** alphabetical by basename across the merged set. Numeric prefixes
+(`10-foo`, `20-bar`) give explicit ordering.
+
+## Hook contract
+
+Each hook is an executable file. `clai` invokes it directly (must have its own
+shebang). The hook receives in the environment:
+
+| Var          | Meaning                                  |
+| ------------ | ---------------------------------------- |
+| `CLAI_AGENT` | The agent name (`claude`, `gemini`, …)   |
+| `CLAI_CWD`   | The directory `clai` was launched in     |
+| `CLAI_ARGS`  | The agent's argv, space-joined, shell-quoted |
+| `CLAI_STAGE` | `pre` or `post`                          |
+| `CLAI_EXIT`  | (post-hooks only) the agent's exit code  |
+
+The hook's own working directory is `$CLAI_CWD`.
+
+**Failure semantics:**
+- Pre-hook non-zero exit → abort. Agent is not launched. Post-hooks do not run.
+- Post-hook non-zero exit → logged to stderr, walk continues. `clai` propagates
+  the agent's exit code, not the hook's.
+
+## Layout
+
+In the tds-utils repo:
+
+```
+bin/clai                              # entry point (zsh on macOS, bash on linux per repo convention)
+clai.d/                               # default hooks shipped with tds-utils
+  claude/
+    pre/
+      10-disable-cloudflare-mcp       # default hook for the original use case
+test/clai/                            # smoke tests
+```
+
+User installation (per the repo's dot.* convention): `~/clai.d/` is symlinked
+to `tds-utils/clai.d/` so global hooks are version-controlled. Project-scoped
+hooks live in `<repo>/clai.d/` and are committed alongside the project.
+
+## The cloudflare-mcp hook (concretely)
+
+`clai.d/claude/pre/10-disable-cloudflare-mcp` reads a list of MCP server names
+from a sibling config file (`~/clai.d/claude/pre/10-disable-cloudflare-mcp.conf`,
+newline-separated) and, using `jq` with atomic tmpfile rename, ensures the
+`~/.claude.json` project entry for `$CLAI_CWD` exists and has those names in
+its `disabledMcpServers` array. Idempotent. Never removes names already
+present.
+
+If a project wants `cloudflare-graphql` enabled, drop a zero-byte
+`<project>/clai.d/claude/pre/10-disable-cloudflare-mcp` to shadow the global
+hook (and run `claude mcp` once to remove the server name from
+`disabledMcpServers` for that project entry).
+
+## Non-goals (for v1)
+
+- No `env`-stage sourced hooks. No `wrap`-stage that takes over `exec`.
+- No async or parallel hook execution.
+- No hook deduplication across stages (a file in `pre/` and `post/` with the
+  same name are unrelated).
+- No support for hooks above `$HOME`.
+
+## Dependencies
+
+- `jq` (for the cloudflare hook's JSON edits — already on user's system).
+- POSIX shell + standard utilities (`find`, `sort`, `realpath`/`readlink -f`).
+- macOS: zsh + BSD utility flags per AGENT.md.

--- a/bin/clai
+++ b/bin/clai
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+# clai — CLI AI launcher with overlay hooks
+#
+# Usage: clai <agent> [args...]
+#
+# Walks $PWD upward to $HOME inclusive, collecting executable hooks from
+# clai.d/<agent>/{pre,post}/ at every level. Hooks merge by basename
+# (closer-to-PWD shadows outer) and run in alphabetical order. Zero-byte
+# files null out an outer hook of the same name.
+#
+# Pre-hook non-zero exit aborts the agent launch and propagates the code.
+# Post-hooks always run on agent exit; their failures are logged, not fatal.
+# clai's exit code is the agent's (or the failing pre-hook's).
+#
+# Hooks see in env: CLAI_AGENT, CLAI_CWD, CLAI_ARGS, CLAI_STAGE, CLAI_EXIT.
+
+set -euo pipefail
+
+# --- Action functions --------------------------------------------------------
+
+# canon_dir <path> — print the canonical (symlinks resolved) absolute dir.
+canon_dir() {
+    ( cd "$1" 2>/dev/null && pwd -P ) || printf '%s' "$1"
+}
+
+# walk_levels <agent> — print each existing clai.d/<agent> directory along the
+# walk from $HOME (outermost) down to $PWD (innermost). When $PWD is not under
+# $HOME, only $HOME's clai.d (if any) is emitted.
+walk_levels() {
+    local agent="$1"
+    local home_real cur_real
+    home_real="$(canon_dir "${HOME}")"
+    cur_real="$(canon_dir "${PWD}")"
+
+    case "${cur_real}/" in
+        "${home_real}/"*) ;;
+        *)
+            local d="${home_real}/clai.d/${agent}"
+            [[ -d "${d}" ]] && printf '%s\n' "${d}"
+            return 0
+            ;;
+    esac
+
+    local -a levels=()
+    local p="${cur_real}"
+    while :; do
+        levels+=("${p}")
+        [[ "${p}" == "${home_real}" ]] && break
+        local parent
+        parent="$(dirname "${p}")"
+        [[ "${parent}" == "${p}" ]] && break
+        p="${parent}"
+    done
+
+    local i
+    for (( i = ${#levels[@]} - 1 ; i >= 0 ; i-- )); do
+        local d="${levels[i]}/clai.d/${agent}"
+        [[ -d "${d}" ]] && printf '%s\n' "${d}"
+    done
+}
+
+# collect_hooks <agent> <stage> — print the absolute path of each hook to run,
+# in alphabetical order by basename, after override-by-filename merge.
+collect_hooks() {
+    local agent="$1"
+    local stage="$2"
+    local -A best=()
+    local -a levels=()
+    readarray -t levels < <(walk_levels "${agent}")
+
+    local lvl
+    for lvl in "${levels[@]}"; do
+        local stage_dir="${lvl}/${stage}"
+        [[ -d "${stage_dir}" ]] || continue
+        local f
+        for f in "${stage_dir}"/*; do
+            [[ -e "${f}" ]] || continue
+            local bn
+            bn="$(basename "${f}")"
+            best["${bn}"]="${f}"
+        done
+    done
+
+    [[ ${#best[@]} -eq 0 ]] && return 0
+    local bn
+    while IFS= read -r bn; do
+        local f="${best[${bn}]}"
+        [[ -s "${f}" ]] || continue
+        [[ -x "${f}" ]] || continue
+        printf '%s\n' "${f}"
+    done < <(printf '%s\n' "${!best[@]}" | LC_ALL=C sort)
+}
+
+# --- Flow --------------------------------------------------------------------
+
+run_hooks() {
+    local stage="$1"
+    local agent="$2"
+    local -a hooks=()
+    readarray -t hooks < <(collect_hooks "${agent}" "${stage}")
+    local hook rc
+    for hook in "${hooks[@]}"; do
+        [[ -n "${hook}" ]] || continue
+        rc=0
+        CLAI_STAGE="${stage}" "${hook}" || rc=$?
+        if (( rc != 0 )); then
+            if [[ "${stage}" == "pre" ]]; then
+                echo "clai: pre-hook ${hook} exited ${rc}; aborting." >&2
+                exit "${rc}"
+            else
+                echo "clai: post-hook ${hook} exited ${rc} (continuing)." >&2
+            fi
+        fi
+    done
+}
+
+launch_agent() {
+    local agent="$1"; shift
+    local -a agent_args=("$@")
+
+    export CLAI_AGENT="${agent}"
+    export CLAI_CWD="${PWD}"
+    local quoted="" a
+    for a in "${agent_args[@]+"${agent_args[@]}"}"; do
+        quoted+="$(printf '%q ' "${a}")"
+    done
+    export CLAI_ARGS="${quoted% }"
+
+    run_hooks pre "${agent}"
+
+    local rc=0
+    "${agent}" "${agent_args[@]+"${agent_args[@]}"}" || rc=$?
+    export CLAI_EXIT="${rc}"
+    run_hooks post "${agent}"
+    exit "${rc}"
+}
+
+# --- Main --------------------------------------------------------------------
+
+usage() {
+    cat <<'EOF'
+clai — CLI AI launcher with overlay hooks
+Usage: clai <agent> [args...]
+EOF
+}
+
+main() {
+    if [[ $# -lt 1 ]]; then
+        usage >&2
+        exit 2
+    fi
+    case "$1" in
+        -h|--help) usage; exit 0 ;;
+    esac
+    local agent="$1"; shift
+    launch_agent "${agent}" "$@"
+}
+
+main "$@"

--- a/clai.d/claude/pre/10-disable-cloudflare-mcp
+++ b/clai.d/claude/pre/10-disable-cloudflare-mcp
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# 10-disable-cloudflare-mcp — clai pre-hook for claude
+#
+# Ensures ~/.claude.json has a project entry for $CLAI_CWD whose
+# disabledMcpServers contains every name listed in the sibling .conf file.
+# Idempotent. Never removes existing entries; only adds missing ones.
+#
+# Skips silently if ~/.claude.json is absent or jq is not installed.
+
+set -euo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+CONF="${HOOK_DIR}/10-disable-cloudflare-mcp.conf"
+CLAUDE_JSON="${HOME}/.claude.json"
+
+read_conf() {
+    [[ -r "${CONF}" ]] || return 0
+    sed -e 's/#.*//' -e '/^[[:space:]]*$/d' "${CONF}"
+}
+
+main() {
+    local -a servers=()
+    readarray -t servers < <(read_conf)
+    [[ ${#servers[@]} -gt 0 ]] || exit 0
+    [[ -f "${CLAUDE_JSON}" ]] || exit 0
+    command -v jq >/dev/null 2>&1 || {
+        echo "clai/disable-cloudflare-mcp: jq not found; skipping." >&2
+        exit 0
+    }
+
+    local cwd
+    cwd="$(cd "${CLAI_CWD:-${PWD}}" && pwd -P)"
+
+    local servers_json
+    servers_json="$(printf '%s\n' "${servers[@]}" | jq -R . | jq -s .)"
+
+    local tmp
+    tmp="$(mktemp "${CLAUDE_JSON}.XXXXXX")"
+    trap 'rm -f "${tmp}"' EXIT
+
+    jq --arg cwd "${cwd}" --argjson add "${servers_json}" '
+        .projects = (.projects // {}) |
+        .projects[$cwd] = (.projects[$cwd] // {}) |
+        .projects[$cwd].disabledMcpServers = (
+            (.projects[$cwd].disabledMcpServers // []) as $cur |
+            $cur + ($add - $cur)
+        )
+    ' "${CLAUDE_JSON}" > "${tmp}"
+
+    jq empty "${tmp}" >/dev/null
+    mv -f "${tmp}" "${CLAUDE_JSON}"
+    trap - EXIT
+}
+
+main "$@"

--- a/clai.d/claude/pre/10-disable-cloudflare-mcp.conf
+++ b/clai.d/claude/pre/10-disable-cloudflare-mcp.conf
@@ -1,0 +1,10 @@
+# Server names (from ~/.claude.json mcpServers) that should be present in
+# every project's disabledMcpServers by default. One name per line. # for
+# comments. To enable one of these for a specific project, drop a zero-byte
+# clai.d/claude/pre/10-disable-cloudflare-mcp file in the project root to
+# shadow this hook there.
+
+cloudflare-graphql
+cloudflare-casb
+cloudflare-bindings
+cloudflare-audit

--- a/test/smoketest_clai/01_pre_hook_runs_then_agent.sh
+++ b/test/smoketest_clai/01_pre_hook_runs_then_agent.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# 01_pre_hook_runs_then_agent.sh
+# Given a single global pre-hook for `claude`, when clai runs, then the hook
+# fires before the agent and both leave traces in expected order.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    init_scenario "01_pre_then_agent"
+    write_hook "${FAKE_HOME}" claude pre 10-mark \
+        $'#!/usr/bin/env bash\nprintf "pre:%s cwd:%s\\n" "${CLAI_AGENT}" "${CLAI_CWD}" >> "${SENTINEL}"\n'
+    make_agent claude 0
+    run_clai workdir claude --some-flag >/dev/null
+
+    local got
+    got="$(cat "${SENTINEL}")"
+    if ! grep -q '^pre:claude' <<<"${got}"; then
+        echo "FAIL: pre-hook trace missing:" >&2; echo "${got}" >&2; return 1
+    fi
+    if ! grep -q '^agent:claude args:--some-flag' <<<"${got}"; then
+        echo "FAIL: agent trace missing:" >&2; echo "${got}" >&2; return 1
+    fi
+    # Order: pre must precede agent.
+    local pre_line agent_line
+    pre_line="$(grep -n '^pre:' <<<"${got}" | head -1 | cut -d: -f1)"
+    agent_line="$(grep -n '^agent:' <<<"${got}" | head -1 | cut -d: -f1)"
+    if (( pre_line >= agent_line )); then
+        echo "FAIL: agent ran before pre-hook" >&2; return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_clai/02_override_by_filename.sh
+++ b/test/smoketest_clai/02_override_by_filename.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# 02_override_by_filename.sh
+# Given a global hook and a project-level hook with the same basename, when
+# clai runs from the project, then only the project-level body executes.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    init_scenario "02_override"
+    write_hook "${FAKE_HOME}" claude pre 10-mark \
+        $'#!/usr/bin/env bash\nprintf "global\\n" >> "${SENTINEL}"\n'
+    local proj="${FAKE_HOME}/proj"
+    write_hook "${proj}" claude pre 10-mark \
+        $'#!/usr/bin/env bash\nprintf "project\\n" >> "${SENTINEL}"\n'
+    make_agent claude 0
+    run_clai proj claude >/dev/null
+
+    local got; got="$(cat "${SENTINEL}")"
+    if grep -q '^global$' <<<"${got}"; then
+        echo "FAIL: global hook should have been shadowed:" >&2; echo "${got}" >&2; return 1
+    fi
+    if ! grep -q '^project$' <<<"${got}"; then
+        echo "FAIL: project hook did not run:" >&2; echo "${got}" >&2; return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_clai/03_alphabetical_order.sh
+++ b/test/smoketest_clai/03_alphabetical_order.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# 03_alphabetical_order.sh
+# Given multiple pre-hooks with different basenames across levels, when clai
+# runs, then they execute in alphabetical order by basename, irrespective of
+# which level they live at.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    init_scenario "03_alpha"
+    # 20- at global, 10- at project — alpha order should put 10- first.
+    write_hook "${FAKE_HOME}" claude pre 20-second \
+        $'#!/usr/bin/env bash\nprintf "20\\n" >> "${SENTINEL}"\n'
+    local proj="${FAKE_HOME}/proj"
+    write_hook "${proj}" claude pre 10-first \
+        $'#!/usr/bin/env bash\nprintf "10\\n" >> "${SENTINEL}"\n'
+    make_agent claude 0
+    run_clai proj claude >/dev/null
+
+    local got; got="$(cat "${SENTINEL}")"
+    local expected=$'10\n20\nagent:claude args:'
+    if [[ "${got}" != "${expected}" ]]; then
+        echo "FAIL: order mismatch" >&2
+        echo "expected:" >&2; echo "${expected}" >&2
+        echo "got:" >&2; echo "${got}" >&2
+        return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_clai/04_zero_byte_disables.sh
+++ b/test/smoketest_clai/04_zero_byte_disables.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# 04_zero_byte_disables.sh
+# Given a global hook and a zero-byte file with the same basename at project
+# level, when clai runs, then the global hook is shadowed and does NOT run.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    init_scenario "04_zero_byte"
+    write_hook "${FAKE_HOME}" claude pre 10-mark \
+        $'#!/usr/bin/env bash\nprintf "global\\n" >> "${SENTINEL}"\n'
+    local proj="${FAKE_HOME}/proj"
+    # Zero-byte shadow.
+    write_hook "${proj}" claude pre 10-mark ""
+    make_agent claude 0
+    run_clai proj claude >/dev/null
+
+    local got; got="$(cat "${SENTINEL}")"
+    if grep -q '^global$' <<<"${got}"; then
+        echo "FAIL: zero-byte should have nulled out the global hook:" >&2
+        echo "${got}" >&2; return 1
+    fi
+    if ! grep -q '^agent:claude' <<<"${got}"; then
+        echo "FAIL: agent did not run:" >&2; echo "${got}" >&2; return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_clai/05_stop_at_home.sh
+++ b/test/smoketest_clai/05_stop_at_home.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# 05_stop_at_home.sh
+# Given a clai.d/ above $HOME (an "ancestor we should ignore"), when clai runs,
+# then that ancestor's hooks are NOT picked up.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    init_scenario "05_stop_at_home"
+    # Plant a hook in the directory ABOVE the fake HOME — must not run.
+    write_hook "$(dirname "${FAKE_HOME}")" claude pre 10-mark \
+        $'#!/usr/bin/env bash\nprintf "above-home\\n" >> "${SENTINEL}"\n'
+    # Plant a hook at HOME — must run.
+    write_hook "${FAKE_HOME}" claude pre 20-home \
+        $'#!/usr/bin/env bash\nprintf "home\\n" >> "${SENTINEL}"\n'
+    make_agent claude 0
+    run_clai proj claude >/dev/null
+
+    local got; got="$(cat "${SENTINEL}")"
+    if grep -q '^above-home$' <<<"${got}"; then
+        echo "FAIL: walked above HOME:" >&2; echo "${got}" >&2; return 1
+    fi
+    if ! grep -q '^home$' <<<"${got}"; then
+        echo "FAIL: HOME-level hook did not run:" >&2; echo "${got}" >&2; return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_clai/06_pre_hook_failure_aborts.sh
+++ b/test/smoketest_clai/06_pre_hook_failure_aborts.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# 06_pre_hook_failure_aborts.sh
+# Given a pre-hook that exits non-zero, when clai runs, then the agent is NOT
+# launched and clai exits with the hook's exit code.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    init_scenario "06_pre_abort"
+    write_hook "${FAKE_HOME}" claude pre 10-fail \
+        $'#!/usr/bin/env bash\nprintf "ran-pre\\n" >> "${SENTINEL}"\nexit 7\n'
+    make_agent claude 0
+
+    local rc=0
+    run_clai proj claude >/dev/null 2>&1 || rc=$?
+    if (( rc != 7 )); then
+        echo "FAIL: expected exit 7, got ${rc}" >&2; return 1
+    fi
+    local got; got="$(cat "${SENTINEL}")"
+    if ! grep -q '^ran-pre$' <<<"${got}"; then
+        echo "FAIL: pre-hook should have run:" >&2; echo "${got}" >&2; return 1
+    fi
+    if grep -q '^agent:claude' <<<"${got}"; then
+        echo "FAIL: agent should not have run:" >&2; echo "${got}" >&2; return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_clai/07_post_hook_after_agent.sh
+++ b/test/smoketest_clai/07_post_hook_after_agent.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# 07_post_hook_after_agent.sh
+# Given a post-hook, when the agent exits, then the post-hook runs with
+# CLAI_EXIT set to the agent's exit code; clai propagates the agent's exit
+# code (not the hook's).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    init_scenario "07_post"
+    write_hook "${FAKE_HOME}" claude post 10-mark \
+        $'#!/usr/bin/env bash\nprintf "post:%s\\n" "${CLAI_EXIT}" >> "${SENTINEL}"\n'
+    make_agent claude 3
+
+    local rc=0
+    run_clai proj claude >/dev/null 2>&1 || rc=$?
+    if (( rc != 3 )); then
+        echo "FAIL: expected agent exit 3 propagated, got ${rc}" >&2; return 1
+    fi
+    local got; got="$(cat "${SENTINEL}")"
+    if ! grep -q '^post:3$' <<<"${got}"; then
+        echo "FAIL: post-hook missing or CLAI_EXIT wrong:" >&2; echo "${got}" >&2; return 1
+    fi
+    # Ordering: agent line precedes post line.
+    local agent_line post_line
+    agent_line="$(grep -n '^agent:' <<<"${got}" | head -1 | cut -d: -f1)"
+    post_line="$(grep -n '^post:' <<<"${got}" | head -1 | cut -d: -f1)"
+    if (( agent_line >= post_line )); then
+        echo "FAIL: post-hook should run after agent" >&2; return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_clai/08_disable_cloudflare_mcp.sh
+++ b/test/smoketest_clai/08_disable_cloudflare_mcp.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# 08_disable_cloudflare_mcp.sh
+# Given a fresh ~/.claude.json with no entry for $PWD and the real
+# 10-disable-cloudflare-mcp hook installed, when clai runs, then the hook
+# adds the configured server names to disabledMcpServers for $PWD.
+# Re-running is idempotent (no duplicates) and respects pre-existing entries
+# (no removals).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "skip: jq not on PATH" >&2; return 0
+    fi
+    init_scenario "08_cloudflare"
+
+    # Symlink the real hook + conf into the fake HOME's clai.d.
+    local real_hook_dir="${REPO_DIR}/clai.d/claude/pre"
+    local fake_pre="${FAKE_HOME}/clai.d/claude/pre"
+    mkdir -p "${fake_pre}"
+    ln -s "${real_hook_dir}/10-disable-cloudflare-mcp" "${fake_pre}/10-disable-cloudflare-mcp"
+    ln -s "${real_hook_dir}/10-disable-cloudflare-mcp.conf" "${fake_pre}/10-disable-cloudflare-mcp.conf"
+
+    # Seed ~/.claude.json with an unrelated project entry that has a pre-existing
+    # disabledMcpServers value (must be preserved).
+    cat > "${FAKE_HOME}/.claude.json" <<EOF
+{
+  "mcpServers": {},
+  "projects": {
+    "/some/other/project": {
+      "disabledMcpServers": ["pre-existing-entry"]
+    }
+  }
+}
+EOF
+
+    make_agent claude 0
+    run_clai proj claude >/dev/null
+
+    local proj_real
+    proj_real="$(cd "${FAKE_HOME}/proj" && pwd -P)"
+
+    # The CWD entry should now contain all configured names.
+    local got_added
+    got_added="$(jq --arg k "${proj_real}" '.projects[$k].disabledMcpServers' "${FAKE_HOME}/.claude.json")"
+    for name in cloudflare-graphql cloudflare-casb cloudflare-bindings cloudflare-audit; do
+        if ! jq -e --arg n "${name}" '. | index($n)' <<<"${got_added}" >/dev/null; then
+            echo "FAIL: ${name} missing from disabledMcpServers" >&2
+            echo "got: ${got_added}" >&2; return 1
+        fi
+    done
+
+    # Pre-existing entry on the unrelated project must be preserved.
+    local preserved
+    preserved="$(jq -r '.projects["/some/other/project"].disabledMcpServers[0]' "${FAKE_HOME}/.claude.json")"
+    if [[ "${preserved}" != "pre-existing-entry" ]]; then
+        echo "FAIL: pre-existing entry on unrelated project was clobbered" >&2; return 1
+    fi
+
+    # Idempotency: second run must not duplicate.
+    run_clai proj claude >/dev/null
+    local count
+    count="$(jq --arg k "${proj_real}" '.projects[$k].disabledMcpServers | length' "${FAKE_HOME}/.claude.json")"
+    if (( count != 4 )); then
+        echo "FAIL: idempotency broken, count=${count}" >&2; return 1
+    fi
+}
+
+main "$@"

--- a/test/smoketest_clai/config.sh
+++ b/test/smoketest_clai/config.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# config.sh — shared environment + helpers for clai smoke tests
+#
+# Each scenario sources this, calls `init_scenario <name>` to mint a fresh fake
+# HOME tree, then uses `write_hook`, `make_agent`, and `run_clai` to set up and
+# exercise. All side effects land under ${SMOKE_TMP}/<scenario>/.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+CLAI_BIN="${REPO_DIR}/bin/clai"
+
+# init_scenario <name>
+#
+# Builds an isolated fake HOME under ${SMOKE_TMP}/<name>/home, exports it as
+# HOME, and clears any inherited PATH so only the fake agent is found.
+init_scenario() {
+    local name="$1"
+    export SCENARIO_DIR="${SMOKE_TMP}/${name}"
+    export FAKE_HOME="${SCENARIO_DIR}/home"
+    export FAKE_BIN="${SCENARIO_DIR}/bin"
+    export SENTINEL="${SCENARIO_DIR}/sentinel.log"
+    mkdir -p "${FAKE_HOME}" "${FAKE_BIN}"
+    : > "${SENTINEL}"
+    export HOME="${FAKE_HOME}"
+    export PATH="${FAKE_BIN}:${PATH}"
+}
+
+# write_hook <dir> <agent> <stage> <basename> <content>
+#
+# Drops an executable hook at <dir>/clai.d/<agent>/<stage>/<basename>. <dir>
+# is created if missing. Content is written verbatim; if empty, file is
+# zero-byte (the override null-out marker).
+write_hook() {
+    local dir="$1"
+    local agent="$2"
+    local stage="$3"
+    local name="$4"
+    local content="$5"
+    local target="${dir}/clai.d/${agent}/${stage}/${name}"
+    mkdir -p "$(dirname "${target}")"
+    printf '%s' "${content}" > "${target}"
+    chmod +x "${target}"
+}
+
+# make_agent <name> [exit_code]
+#
+# Installs a fake agent at ${FAKE_BIN}/<name> that appends one line to
+# ${SENTINEL} ("agent:<name> args:<argv>") and exits with the given code.
+make_agent() {
+    local name="$1"
+    local rc="${2:-0}"
+    local target="${FAKE_BIN}/${name}"
+    cat > "${target}" <<EOF
+#!/usr/bin/env bash
+printf 'agent:%s args:%s\n' "${name}" "\$*" >> "${SENTINEL}"
+exit ${rc}
+EOF
+    chmod +x "${target}"
+}
+
+# run_clai <cwd> <agent> [args...]
+#
+# cd into <cwd> (relative paths resolved under FAKE_HOME) and runs the real
+# bin/clai with the rest of the args. Returns clai's exit code.
+run_clai() {
+    local cwd="$1"; shift
+    case "${cwd}" in
+        /*) ;;
+        *) cwd="${FAKE_HOME}/${cwd}" ;;
+    esac
+    mkdir -p "${cwd}"
+    ( cd "${cwd}" && "${CLAI_BIN}" "$@" )
+}
+
+export -f init_scenario write_hook make_agent run_clai

--- a/test/smoketest_clai/run_all.sh
+++ b/test/smoketest_clai/run_all.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# run_all.sh — orchestrate clai smoke tests
+#
+# Hermetic: every scenario builds a fake $HOME tree under SMOKE_TMP, overrides
+# HOME for the duration, and asserts on side-effect files written by fake
+# hooks/agents. No real ~/.claude.json edits. No real agent launches.
+#
+# Usage: ./test/smoketest_clai/run_all.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+red()   { printf "\033[1;31m%s\033[0m" "$1"; }
+green() { printf "\033[1;32m%s\033[0m" "$1"; }
+bold()  { printf "\033[1m%s\033[0m" "$1"; }
+
+run_test() {
+    local script="$1"
+    local name
+    name="$(basename "${script}" .sh)"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    printf "  %s ... " "$(bold "${name}")"
+    if ( bash "${script}" ); then
+        printf "%s\n" "$(green PASS)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf "%s\n" "$(red FAIL)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+main() {
+    export SMOKE_TMP
+    SMOKE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/clai-smoke.XXXXXX")"
+    trap 'rm -rf "${SMOKE_TMP}"' EXIT
+
+    printf "clai smoke tests (tmp=%s)\n" "${SMOKE_TMP}"
+    for script in "${SCRIPT_DIR}"/[0-9][0-9]_*.sh; do
+        [[ -f "${script}" ]] || continue
+        run_test "${script}"
+    done
+    printf "\n%d run, %d passed, %d failed\n" \
+        "${TESTS_RUN}" "${TESTS_PASSED}" "${TESTS_FAILED}"
+    [[ "${TESTS_FAILED}" -eq 0 ]]
+}
+
+main "$@"


### PR DESCRIPTION
Walks $PWD upward to $HOME, collecting executable hooks from clai.d/<agent>/{pre,post}/ at every level. Hooks merge by basename (closer-to-PWD shadows outer; zero-byte file nulls out a hook) and run in alphabetical order. Pre-hook failure aborts the agent launch.

Ships with the 10-disable-cloudflare-mcp hook that idempotently adds Cloudflare MCP server names to ~/.claude.json's disabledMcpServers for the current project — born to keep those servers defined globally but disabled by default for new projects.

8 hermetic smoke tests cover the overlay walk semantics + the hook.