### PR TITLE
docs(todo): add Task SEC1 — rotate GH Packages PAT, move off plaintext

### DIFF
--- a/TODO_PLAN.md
+++ b/TODO_PLAN.md
@@ -78,6 +78,10 @@ Pre-existing issues in the gadmin GitHub tools, surfaced by Copilot review on PR
 - [ ] Task 5: Phase 2 — Implement `SqliteVecAdapter` + `OllamaAdapter` for lighter-weight alternative.
 - [ ] Task 6 (future): Compressed log storage — implement compression in archive pipeline, update file-access abstraction, get smoke test S8 passing.
 
+### Security / Credentials
+
+- [ ] Task SEC1: **Rotate the GitHub Packages PAT in `~/.npmrc` and switch to a non-plaintext source.** Current state: a read-only PAT sits cleartext in `~/.npmrc` (`//npm.pkg.github.com/:_authToken=ghp_...`) and was emitted twice into a Claude transcript during a Mini Shai-Hulud audit (CVE-2026-45321, 2026-05-11). Replace with shell wrappers around `npm`/`pnpm`/`yarn`/`npx` that hydrate `${GITHUB_PACKAGES_TOKEN}` at call time. Preferred source: `gh auth token` (gh's own creds live in macOS keychain). Fallback: `security find-generic-password -s github-packages-pat -a 9atatimer -w`. The `.npmrc` line becomes `${GITHUB_PACKAGES_TOKEN}` so no secret on disk. Wrappers land in `bash/dot.bashrc.d/` (or `macos/` if zsh-only). Read-only scope limits blast radius but the token is functionally burned; rotate at revoke time.
+
 ---
 
 ## Lessons Learned


### PR DESCRIPTION
## Summary

- Triaged during Mini Shai-Hulud (CVE-2026-45321) audit: a read-only GH Packages PAT in `~/.npmrc` was emitted into a Claude transcript and should be treated as burned.
- Captures the rotation work as **Task SEC1** under a new `### Security / Credentials` section in `TODO_PLAN.md`.
- Records the preferred remediation: shell wrappers around `npm` / `pnpm` / `yarn` / `npx` that hydrate `${GITHUB_PACKAGES_TOKEN}` from `gh auth token` (or `security find-generic-password` as fallback), with `.npmrc` referencing the env var instead of holding the secret.

## Test plan

- [ ] `TODO_PLAN.md` renders correctly on GitHub
- [ ] Task SEC1 description is self-contained enough for a cold-start agent to act on

🤖 Generated with [Claude Code](https://claude.com/claude-code)