### PR TITLE
feat(goldfish): wire into shell via bin/ symlink and gf alias

### DIFF
--- a/TODO_PLAN.md
+++ b/TODO_PLAN.md
@@ -55,17 +55,6 @@ Pre-existing issues in the gadmin GitHub tools, surfaced by Copilot review on PR
 - [ ] Task L2: **Adopt meaningful session names** — default numeric (`18`, `19`, `20`…) make `tmux ls` and the new title-string both worse than they need to be.
 - [ ] Task L3: **Handle session-rename → log-path drift** — `tmux_logging.sh` bakes `#S` at pipe-pane time, so renaming a live session splits its logs across old and new dirs.
 
-### goldfish (post-MVP follow-ups)
-
-- [ ] Task G4: **macOS smoke test.** Linux smoke suite shipped in PR #18 (6/6
-  green); the macOS cwd-detection path (`lsof -p <pid> -d cwd -Fn`) is still
-  unproven. Run goldfish on a real macOS box, fix anything that breaks, and
-  add a `test/smoketest_goldfish/` scenario for the bits that can be
-  exercised hermetically (agent detection with `prctl` is Linux-only, so
-  that test has to stay platform-gated).
-- [ ] Task G8: **`bin/goldfish` symlink.** Optional, once the `goldfish/`
-  layout settles. Currently invoked as `goldfish/goldfish`.
-
 ### Pipeline (implementation work driven by smoke tests above)
 
 - [ ] Task 2b: Implement `Segmenter` — reads log text, detects span boundaries (prompt lines with cd, tool switches, idle gaps), returns `Span` objects with byte offsets. Pure domain logic in `search/domain/segmenter.py`. Should accept text, not file paths — keeps it pure for future compression abstraction.
@@ -123,3 +112,4 @@ Pre-existing issues in the gadmin GitHub tools, surfaced by Copilot review on PR
   - **G6** `-v` / `--verbose`: lists every process whose cwd is inside a tracked repo (not just the agent whitelist), grouped by repo. Catches wrapper-launched agents.
   - **G7** `--include-org` / `--exclude-org`: repeatable filter flags, exclude wins over include.
   - **G4 (Linux scaffolding)**: hermetic `test/smoketest_goldfish/` bash suite, 6 scenarios, all green on Linux. macOS verification (`lsof` path) remains open as the G4 entry above.
+- [x] Tasks G4 (macOS half) + G8: Verified goldfish on macOS (6/6 smoketests green, real-run JSON output sane). Added `bin/goldfish` symlink and `gf` alias in `macos/dot.alias`.

--- a/bin/goldfish
+++ b/bin/goldfish
@@ -1,0 +1,1 @@
+../goldfish/goldfish

--- a/macos/dot.alias
+++ b/macos/dot.alias
@@ -26,3 +26,6 @@ ssh() {
 alias tailscale="/Applications/Tailscale.app/Contents/MacOS/Tailscale"
 
 alias bit-tunnel="ssh -L 5678:127.0.0.1:5678 stumpf@100.125.95.68"
+
+# goldfish — recent-work report across repos
+alias gf=goldfish


### PR DESCRIPTION
## Summary

- Add `bin/goldfish` symlink → `../goldfish/goldfish` so it's invocable as `goldfish` from anywhere on `$PATH`.
- Add `alias gf=goldfish` in `macos/dot.alias`.
- Mark Tasks G4 (macOS half) and G8 done in `TODO_PLAN.md`.

## Tire-kicking (macOS)

- `test/smoketest_goldfish/run_all.sh` — **6/6 PASS**
- `goldfish --json` — real run produces sane output; `lsof` cwd path doesn't crash. Clears the G4 macOS verification that PR #18 left open.

## Test plan

- [x] Smoketests pass on macOS (6/6)
- [x] `which goldfish` resolves through `bin/`
- [x] `goldfish --help` works
- [ ] `gf` alias picks up after re-sourcing `dot.alias`

## Notes

Linux side: `bash/` has no equivalent aliases file (just one inline alias in `dot.bashrc`), so `gf` is macOS-only for now. Flagged in conversation but intentionally not solved — no Linux box is asking for it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)