### PR TITLE
feat(goldfish): fzf checkbox TUI for --manage-blacklist

### DIFF
--- a/goldfish/_blacklist_toggle.py
+++ b/goldfish/_blacklist_toggle.py
@@ -36,8 +36,11 @@ def main(argv: list[str]) -> int:
         else:
             out.append(line)
     tmp = state_path.with_suffix(state_path.suffix + ".tmp")
-    tmp.write_text("\n".join(out))
-    tmp.replace(state_path)
+    try:
+        tmp.write_text("\n".join(out))
+        tmp.replace(state_path)
+    except OSError:
+        return 1
     return 0
 
 

--- a/goldfish/_blacklist_toggle.py
+++ b/goldfish/_blacklist_toggle.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Flip the marker on one line of a state file. Invoked by fzf's space bind.
+
+Usage: _blacklist_toggle.py <state-file> <line>
+
+Reads the state file, replaces the first line equal to <line> with its
+toggled form (via `core.toggle_marker_line`), and atomically writes back.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+sys.path.insert(0, str(HERE))
+
+from core import toggle_marker_line  # noqa: E402
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 3:
+        return 2
+    state_path = Path(argv[1])
+    target = argv[2]
+    try:
+        text = state_path.read_text()
+    except OSError:
+        return 1
+    lines = text.splitlines()
+    flipped = False
+    out: list[str] = []
+    for line in lines:
+        if not flipped and line == target:
+            out.append(toggle_marker_line(line))
+            flipped = True
+        else:
+            out.append(line)
+    tmp = state_path.with_suffix(state_path.suffix + ".tmp")
+    tmp.write_text("\n".join(out))
+    tmp.replace(state_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/goldfish/core.py
+++ b/goldfish/core.py
@@ -352,6 +352,48 @@ def apply_blacklist(
     return [r for r in rows if r.name not in blacklist]
 
 
+# --- Marker state (fzf-driven blacklist picker) ------------------------------
+
+_MARKER_ON = "[x] "
+_MARKER_OFF = "[ ] "
+
+
+def format_marker_state(
+    names: Iterable[str],
+    *,
+    selected: Iterable[str],
+) -> str:
+    """Render `names` as marker-prefixed lines, preserving input order.
+
+    Selected names get '[x] '; the rest get '[ ] '. Feeds the fzf picker.
+    """
+    sel = set(selected)
+    return "\n".join(
+        (_MARKER_ON if n in sel else _MARKER_OFF) + n for n in names
+    )
+
+
+def parse_marker_state(text: str) -> frozenset[str]:
+    """Recover the set of checked names from a marker-state string.
+
+    Only lines starting with '[x] ' contribute. Anything else is dropped.
+    """
+    return frozenset(
+        line[len(_MARKER_ON):]
+        for line in text.splitlines()
+        if line.startswith(_MARKER_ON)
+    )
+
+
+def toggle_marker_line(line: str) -> str:
+    """Flip the marker prefix on a single line. No-op on unrecognized lines."""
+    if line.startswith(_MARKER_ON):
+        return _MARKER_OFF + line[len(_MARKER_ON):]
+    if line.startswith(_MARKER_OFF):
+        return _MARKER_ON + line[len(_MARKER_OFF):]
+    return line
+
+
 # --- Actionability filter ----------------------------------------------------
 
 def is_actionable(row: RepoRow) -> bool:

--- a/goldfish/goldfish
+++ b/goldfish/goldfish
@@ -259,8 +259,7 @@ def run_manage_blacklist(args: argparse.Namespace) -> int:
         include=tuple(args.include_org),
         exclude=tuple(args.exclude_org),
     )
-    rows = sort_rows(rows)
-    all_names = [r.name for r in rows]
+    all_names = sorted((r.name for r in rows), key=str.casefold)
     if not all_names:
         print("(no repos found to manage)", file=sys.stderr)
         return 0

--- a/goldfish/goldfish
+++ b/goldfish/goldfish
@@ -43,6 +43,7 @@ from shell import (  # noqa: E402
     inspect_local,
     load_blacklist,
     load_cached_clones,
+    pick_blacklist_via_fzf,
     running_agents,
     save_blacklist,
     save_cached_clones,
@@ -241,7 +242,11 @@ def _build_row(
 
 
 def run_manage_blacklist(args: argparse.Namespace) -> int:
-    """Interactive line-based picker: toggle blacklist entries, save, exit."""
+    """Toggle blacklist entries interactively, then save and exit.
+
+    Prefers an fzf-driven checkbox picker; falls back to a numbered-list loop
+    when fzf is not on PATH.
+    """
     config = load_config()
     rows, _ = gather(
         config,
@@ -260,7 +265,48 @@ def run_manage_blacklist(args: argparse.Namespace) -> int:
         print("(no repos found to manage)", file=sys.stderr)
         return 0
 
-    selected = set(load_blacklist())
+    current = load_blacklist()
+    if have("fzf"):
+        return _run_manage_blacklist_fzf(all_names, current)
+    print(
+        "goldfish: fzf not found on PATH; using numbered-list fallback "
+        "(brew install fzf for the TUI).",
+        file=sys.stderr,
+    )
+    return _run_manage_blacklist_legacy(all_names, current)
+
+
+def _run_manage_blacklist_fzf(
+    all_names: list[str],
+    current: frozenset[str],
+) -> int:
+    """fzf-driven picker. Saves on Enter; no-op on Esc."""
+    new_selection = pick_blacklist_via_fzf(all_names, current)
+    if new_selection is None:
+        print("(cancelled; no changes saved)", file=sys.stderr)
+        return 0
+    if new_selection == current:
+        print("(no changes)", file=sys.stderr)
+        return 0
+    if save_blacklist(new_selection):
+        print(
+            f"saved {len(new_selection)} entries to {blacklist_path()}",
+            file=sys.stderr,
+        )
+        return 0
+    print(
+        f"goldfish: failed to write {blacklist_path()}; changes NOT saved",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def _run_manage_blacklist_legacy(
+    all_names: list[str],
+    current: frozenset[str],
+) -> int:
+    """Numbered-list picker used when fzf is unavailable."""
+    selected = set(current)
     selected_at_start = frozenset(selected)
     print(f"goldfish — manage blacklist ({blacklist_path()})")
     print("Type number(s) or name(s) to toggle (comma/space separated).")

--- a/goldfish/shell.py
+++ b/goldfish/shell.py
@@ -9,8 +9,10 @@ from __future__ import annotations
 import json
 import os
 import platform
+import shlex
 import shutil
 import subprocess
+import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
@@ -23,11 +25,13 @@ from core import (
     GitDirtyState,
     enclosing_repo,
     first_meaningful_line,
+    format_marker_state,
     parse_blacklist,
     parse_clones_cache,
     parse_gh_repo_list,
     parse_git_porcelain,
     parse_lsof_cwd,
+    parse_marker_state,
     parse_ps,
     parse_todo_plan,
     serialize_blacklist,
@@ -194,6 +198,63 @@ def save_blacklist(names: frozenset[str]) -> bool:
     except OSError:
         return False
     return True
+
+
+def pick_blacklist_via_fzf(
+    all_names: list[str],
+    current: frozenset[str],
+) -> frozenset[str] | None:
+    """Interactive checkbox picker via fzf.
+
+    Renders `all_names` with '[x]'/'[ ]' markers reflecting `current`, then runs
+    fzf with a space-toggle binding. Returns the new selection on Enter; None
+    on Esc / interrupt / fzf-not-found.
+    """
+    here = Path(__file__).resolve().parent
+    toggle_helper = here / "_blacklist_toggle.py"
+    state_fd, state_name = tempfile.mkstemp(
+        prefix="goldfish-blacklist-", suffix=".state"
+    )
+    state_path = Path(state_name)
+    try:
+        with os.fdopen(state_fd, "w") as f:
+            f.write(format_marker_state(all_names, selected=current))
+        toggle_cmd = (
+            f"python3 {shlex.quote(str(toggle_helper))} "
+            f"{shlex.quote(str(state_path))} {{}}"
+        )
+        reload_cmd = f"cat {shlex.quote(str(state_path))}"
+        header = (
+            f"Space toggle  -  Enter save  -  Esc cancel    "
+            f"({len(current)}/{len(all_names)} blacklisted at start)"
+        )
+        cmd = [
+            "fzf",
+            "--no-sort",
+            "--reverse",
+            "--cycle",
+            "--no-multi",
+            "--header", header,
+            "--bind", f"space:execute-silent({toggle_cmd})+reload({reload_cmd})",
+        ]
+        try:
+            with state_path.open("rb") as stdin:
+                proc = subprocess.run(
+                    cmd,
+                    stdin=stdin,
+                    stdout=subprocess.DEVNULL,
+                    check=False,
+                )
+        except FileNotFoundError:
+            return None
+        if proc.returncode != 0:
+            return None
+        return parse_marker_state(state_path.read_text())
+    finally:
+        try:
+            state_path.unlink()
+        except OSError:
+            pass
 
 
 def _find_git_dirs(root: Path, max_depth: int) -> list[Path]:

--- a/goldfish/test_core.py
+++ b/goldfish/test_core.py
@@ -17,6 +17,7 @@ from core import (
     apply_org_filter,
     enclosing_repo,
     first_meaningful_line,
+    format_marker_state,
     format_processes,
     format_table,
     is_actionable,
@@ -26,12 +27,14 @@ from core import (
     parse_git_porcelain,
     parse_gh_repo_list,
     parse_lsof_cwd,
+    parse_marker_state,
     parse_ps,
     parse_todo_plan,
     rows_to_json,
     serialize_blacklist,
     serialize_clones_cache,
     sort_rows,
+    toggle_marker_line,
 )
 
 
@@ -663,6 +666,73 @@ def test_format_table_bl_marker_only_for_blacklisted_row() -> None:
     b_cells = [c.strip() for c in b_line.split("  ") if c.strip()]
     assert b_cells.count("*") == 1
     assert a_cells.count("*") == 0
+
+
+# --- marker state (fzf TUI helpers) -----------------------------------------
+
+def test_format_marker_state_marks_selected_and_unselected() -> None:
+    """Given names and a selected subset, each line carries the right marker."""
+    out = format_marker_state(["a/x", "b/y", "c/z"], selected={"b/y"})
+    assert out.splitlines() == ["[ ] a/x", "[x] b/y", "[ ] c/z"]
+
+
+def test_format_marker_state_preserves_input_order() -> None:
+    """Given names in a specific order, that order is preserved (fzf is --no-sort)."""
+    out = format_marker_state(["z/z", "a/a", "m/m"], selected=frozenset())
+    assert [line[4:] for line in out.splitlines()] == ["z/z", "a/a", "m/m"]
+
+
+def test_format_marker_state_empty_names_returns_empty_string() -> None:
+    """Given no names, returns the empty string."""
+    assert format_marker_state([], selected={"a/x"}) == ""
+
+
+def test_parse_marker_state_extracts_only_checked_names() -> None:
+    """Given a multi-line state, returns the set of names prefixed with '[x] '."""
+    text = "[x] a/x\n[ ] b/y\n[x] c/z\n"
+    assert parse_marker_state(text) == frozenset({"a/x", "c/z"})
+
+
+def test_parse_marker_state_ignores_unchecked_and_blank_lines() -> None:
+    """Given '[ ] ' lines and blank lines, only '[x] ' lines contribute."""
+    text = "\n[ ] a/x\n\n[x] b/y\n"
+    assert parse_marker_state(text) == frozenset({"b/y"})
+
+
+def test_parse_marker_state_ignores_malformed_lines() -> None:
+    """Given lines without a recognized prefix, they are silently dropped."""
+    text = "garbage\n[x] a/x\nrandom [x] mid\n[X] b/y\n"
+    assert parse_marker_state(text) == frozenset({"a/x"})
+
+
+def test_format_then_parse_round_trips() -> None:
+    """Given a selection, format then parse recovers the same selection."""
+    names = ["a/x", "b/y", "c/z", "d/w"]
+    selected = frozenset({"a/x", "c/z"})
+    text = format_marker_state(names, selected=selected)
+    assert parse_marker_state(text) == selected
+
+
+def test_toggle_marker_line_flips_checked_to_unchecked() -> None:
+    """Given a '[x] ' line, toggle returns the '[ ] ' form."""
+    assert toggle_marker_line("[x] a/x") == "[ ] a/x"
+
+
+def test_toggle_marker_line_flips_unchecked_to_checked() -> None:
+    """Given a '[ ] ' line, toggle returns the '[x] ' form."""
+    assert toggle_marker_line("[ ] a/x") == "[x] a/x"
+
+
+def test_toggle_marker_line_is_noop_on_unrecognized() -> None:
+    """Given a line without a recognized marker, toggle returns it unchanged."""
+    assert toggle_marker_line("garbage") == "garbage"
+    assert toggle_marker_line("") == ""
+    assert toggle_marker_line("[?] foo") == "[?] foo"
+
+
+def test_toggle_marker_line_preserves_trailing_content() -> None:
+    """Given a line with content after the name, that content is preserved."""
+    assert toggle_marker_line("[x] a/x  ") == "[ ] a/x  "
 
 
 def test_format_table_next_task_truncated() -> None:


### PR DESCRIPTION
## Summary

- Replace the numbered-list `--manage-blacklist` picker with an fzf-driven checkbox TUI when fzf is on PATH; preserve the old loop as a fallback. The numbered picker collapses at ~200 candidate repos; fzf brings fuzzy filter + visual checkboxes.
- The fzf reload idiom drives state: render `[x]/[ ]` lines into a tempfile, space-bind invokes a tiny Python helper that flips the marker on the focused line and reloads fzf from the file. Enter saves; Esc cancels.
- Sort the picker case-insensitively by name (the main `goldfish` table keeps its activity sort).

## Test plan

- [x] `pytest goldfish/test_core.py -q` — 82/82 (added 10 BDD tests for `format_marker_state` / `parse_marker_state` / `toggle_marker_line`)
- [x] Toggle helper round-trips on a real file
- [x] `goldfish --help` parses; both fzf and legacy code paths import cleanly
- [ ] Manual: run `gf --manage-blacklist`, space to toggle a few, Enter to save, confirm `~/.config/goldfish/blacklist.json` updates
- [ ] Manual: run with `PATH` stripped of fzf to exercise the numbered-loop fallback