### PR TITLE
chore(gitignore): ignore tmp/ and .designomatic/ runtime dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ __pycache__/
 emacs/dot.emacs.d/elisp/emacs-mcp-server/
 .claude
 memory/
+tmp/
+.designomatic/


### PR DESCRIPTION
## Summary

Adds two paths to `.gitignore` to prevent runtime / scratch dirs from littering `git status`:

- **`tmp/`** — scratch directory used during local experimentation
- **`.designomatic/`** — per-run artifact dir created by `designomatic-exec` (reviewer raw output, editor proposals, critic scope/quality decisions). The canonical structured JSONL run log lives under `~/.designomatic/runs/<utc>-<stem>/` and is unaffected by this change; only the per-repo working-tree artifact dir is being ignored.

## Why

Running `designomatic-exec` inside any tds-utils worktree creates `.designomatic/` next to the draft being reviewed. Without this gitignore entry, every run leaves an untracked dir cluttering `git status` and risking accidental commits of run state.

## Test plan
- [x] `git status` after a designomatic run no longer shows `.designomatic/` as untracked
- [x] Diff is 2 lines, no other files affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)