### PR TITLE
feat(macos): add $HOME/go/bin to PATH for Go-installed tools

### DIFF
--- a/macos/dot.zshrc
+++ b/macos/dot.zshrc
@@ -1,5 +1,8 @@
 export PATH="/Users/stumpf/workplace/tds-utils/bin:$PATH"
 
+# Go-installed tools (go install puts binaries in ~/go/bin)
+export PATH="$HOME/go/bin:$PATH"
+
 # NVM magic
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
## Summary

Adds `$HOME/go/bin` to PATH in `macos/dot.zshrc` so `go install`-ed binaries are discoverable. Standard golang dev convention — `go install` defaults to dropping built binaries in `$GOPATH/bin`, which is `~/go/bin` when GOPATH is unset.

## Diff

```diff
 export PATH="/Users/stumpf/workplace/tds-utils/bin:$PATH"
+
+# Go-installed tools (go install puts binaries in ~/go/bin)
+export PATH="$HOME/go/bin:$PATH"
+
 # NVM magic
 export NVM_DIR="$HOME/.nvm"
```

## Test plan
- [x] After sourcing dot.zshrc, `echo $PATH | tr ':' '\n' | grep go/bin` resolves
- [x] `go install`-ed tools are immediately invokable without explicit path

🤖 Generated with [Claude Code](https://claude.com/claude-code)