### PR TITLE
feat(emacs): wire eldocker docker/k8s porcelain into init.el

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@ __pycache__/
 .pytest_cache/
 
 emacs/dot.emacs.d/elisp/emacs-mcp-server/
-emacs/dot.emacs.d/elisp/eldocker/
 .claude
 memory/
 tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ __pycache__/
 .pytest_cache/
 
 emacs/dot.emacs.d/elisp/emacs-mcp-server/
+emacs/dot.emacs.d/elisp/eldocker/
 .claude
 memory/
 tmp/

--- a/emacs/dot.emacs.d/init.el
+++ b/emacs/dot.emacs.d/init.el
@@ -453,12 +453,8 @@
   :config
   (add-hook 'emacs-startup-hook #'mcp-server-start-unix))
 
-(use-package company
-  :ensure t
-  :defer t)
-
 (use-package eltainer
-  :load-path "~/.emacs.d/elisp/eldocker"
+  :load-path "~/workplace/9atatimer/eldocker"
   :commands (eltainer docker k8s)
   :bind ("C-c d" . eltainer))
 

--- a/emacs/dot.emacs.d/init.el
+++ b/emacs/dot.emacs.d/init.el
@@ -453,6 +453,15 @@
   :config
   (add-hook 'emacs-startup-hook #'mcp-server-start-unix))
 
+(use-package company
+  :ensure t
+  :defer t)
+
+(use-package eltainer
+  :load-path "~/.emacs.d/elisp/eldocker"
+  :commands (eltainer docker k8s)
+  :bind ("C-c d" . eltainer))
+
 ;;;;;;
 ;;;;;;
 ;; temporary hacks to try to get emacs to follow prettier standards


### PR DESCRIPTION
## Summary
- Wire [9atatimer/eldocker](https://github.com/9atatimer/eldocker) (fork of [JacobGabrielson/eldocker](https://github.com/JacobGabrielson/eldocker) — pure-Elisp Docker + k8s porcelain, magit-section style) into `init.el` via `use-package` + `:load-path "~/workplace/9atatimer/eldocker"`.
- Lazy-loaded via `:commands (eltainer docker k8s)`. Bind `C-c d` to `M-x eltainer`.
- The fork drops `eldocker/k8s/k8s.el`'s hard `(require 'company)`, so no new completion-frontend dep is introduced.

## Test plan
- [x] Batch: `emacs --batch -l init.el` confirms `eltainer` is autoloaded, `C-c d` binds to it, and `~/workplace/9atatimer/eldocker` is on `load-path`.
- [x] Batch force-load: `(require 'eltainer)` resolves the full transitive require chain (eltainer-ui, eltainer-terminal, docker, k8s) with no errors.
- [ ] Interactive: open GUI Emacs, `C-c d` brings up the eltainer dashboard against the running Docker daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)