### PR TITLE
feat(clai): add --list-agents and flesh out --help

### DIFF
--- a/CLAI.DESIGN.md
+++ b/CLAI.DESIGN.md
@@ -10,11 +10,19 @@ projects" — but the hook framework is general.
 ## Invocation
 
 ```
-clai <agent> [args...]
+clai <agent> [args...]    # launch <agent> with its pre/post hooks
+clai --list-agents        # list agents that have hooks configured
+clai --help               # show usage
 ```
 
 Runs all pre-hooks for `<agent>`, then `exec`s `<agent> [args...]`. Post-hooks
 fire after the agent exits.
+
+`--list-agents` (`-l`) walks `$PWD` → `$HOME` and prints, sorted and
+de-duplicated, the name of every agent that has a `clai.d/<agent>/` directory
+on that walk — i.e. the agents you have hooks configured for. Names go to
+stdout (pipeable); a "none found" note goes to stderr. `--help` (`-h`) prints
+usage.
 
 ## Hook discovery — overlay walk
 
@@ -66,7 +74,7 @@ clai.d/                               # default hooks shipped with tds-utils
   claude/
     pre/
       10-disable-cloudflare-mcp       # default hook for the original use case
-test/clai/                            # smoke tests
+test/smoketest_clai/                   # smoke tests
 ```
 
 User installation (per the repo's dot.* convention): `~/clai.d/` is symlinked

--- a/CLAI.DESIGN.md
+++ b/CLAI.DESIGN.md
@@ -18,13 +18,13 @@ clai --help               # show usage
 Runs all pre-hooks for `<agent>`, then `exec`s `<agent> [args...]`. Post-hooks
 fire after the agent exits.
 
-`--list-agents` (`-l`) walks `$PWD` → `$HOME` and prints, sorted and
+`--list-agents` (`-l`) walks `$PWD` -> `$HOME` and prints, sorted and
 de-duplicated, the name of every agent that has a `clai.d/<agent>/` directory
-on that walk — i.e. the agents you have hooks configured for. Names go to
+on that walk -- i.e. the agents you have hooks configured for. Names go to
 stdout (pipeable); a "none found" note goes to stderr. `--help` (`-h`) prints
 usage.
 
-## Hook discovery — overlay walk
+## Hook discovery -- overlay walk
 
 Walk from `$PWD` upward to `$HOME` **inclusive**. At each directory level, if
 `clai.d/<agent>/<stage>/` exists, its contents contribute to the hook set for

--- a/bin/clai
+++ b/bin/clai
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # clai — CLI AI launcher with overlay hooks
 #
-# Usage: clai <agent> [args...]
+# Usage: clai <agent> [args...]   |   clai --list-agents   |   clai --help
 #
 # Walks $PWD upward to $HOME inclusive, collecting executable hooks from
 # clai.d/<agent>/{pre,post}/ at every level. Hooks merge by basename
@@ -23,11 +23,10 @@ canon_dir() {
     ( cd "$1" 2>/dev/null && pwd -P ) || printf '%s' "$1"
 }
 
-# walk_levels <agent> — print each existing clai.d/<agent> directory along the
-# walk from $HOME (outermost) down to $PWD (innermost). When $PWD is not under
-# $HOME, only $HOME's clai.d (if any) is emitted.
-walk_levels() {
-    local agent="$1"
+# walk_base_dirs — print each directory level from $HOME (outermost) down to
+# $PWD (innermost), one per line. When $PWD is not within $HOME, only $HOME is
+# emitted — the walk never climbs above $HOME.
+walk_base_dirs() {
     local home_real cur_real
     home_real="$(canon_dir "${HOME}")"
     cur_real="$(canon_dir "${PWD}")"
@@ -35,8 +34,7 @@ walk_levels() {
     case "${cur_real}/" in
         "${home_real}/"*) ;;
         *)
-            local d="${home_real}/clai.d/${agent}"
-            [[ -d "${d}" ]] && printf '%s\n' "${d}"
+            printf '%s\n' "${home_real}"
             return 0
             ;;
     esac
@@ -54,9 +52,38 @@ walk_levels() {
 
     local i
     for (( i = ${#levels[@]} - 1 ; i >= 0 ; i-- )); do
-        local d="${levels[i]}/clai.d/${agent}"
-        [[ -d "${d}" ]] && printf '%s\n' "${d}"
+        printf '%s\n' "${levels[i]}"
     done
+}
+
+# walk_levels <agent> — print each existing clai.d/<agent> directory along the
+# walk from $HOME (outermost) down to $PWD (innermost).
+walk_levels() {
+    local agent="$1"
+    local base
+    while IFS= read -r base; do
+        local d="${base}/clai.d/${agent}"
+        [[ -d "${d}" ]] && printf '%s\n' "${d}"
+    done < <(walk_base_dirs)
+}
+
+# list_agents — print the name of every agent that has a clai.d/<agent>/
+# directory anywhere on the walk, de-duplicated and sorted.
+list_agents() {
+    local -A seen=()
+    local base
+    while IFS= read -r base; do
+        local clai_dir="${base}/clai.d"
+        [[ -d "${clai_dir}" ]] || continue
+        local d
+        for d in "${clai_dir}"/*/; do
+            [[ -d "${d}" ]] || continue
+            seen["$(basename "${d}")"]=1
+        done
+    done < <(walk_base_dirs)
+
+    [[ ${#seen[@]} -eq 0 ]] && return 0
+    printf '%s\n' "${!seen[@]}" | LC_ALL=C sort
 }
 
 # collect_hooks <agent> <stage> — print the absolute path of each hook to run,
@@ -135,12 +162,46 @@ launch_agent() {
     exit "${rc}"
 }
 
+run_list_agents() {
+    local -a agents=()
+    readarray -t agents < <(list_agents)
+    if [[ ${#agents[@]} -eq 0 ]]; then
+        echo "clai: no agents with hooks found on the walk from ${PWD} to ${HOME}." >&2
+        return 0
+    fi
+    printf '%s\n' "${agents[@]}"
+}
+
 # --- Main --------------------------------------------------------------------
 
 usage() {
     cat <<'EOF'
 clai — CLI AI launcher with overlay hooks
-Usage: clai <agent> [args...]
+
+Usage:
+  clai <agent> [args...]   Launch <agent>, running its pre/post hooks.
+  clai --list-agents       List agents that have hooks configured.
+  clai --help              Show this help.
+
+Description:
+  Walks $PWD upward to $HOME inclusive, collecting executable hooks from
+  clai.d/<agent>/{pre,post}/ at every level. Hooks merge by basename
+  (closer-to-PWD shadows outer) and run in alphabetical order. Zero-byte
+  files null out an outer hook of the same name.
+
+  A failing pre-hook aborts the launch; post-hooks always run after the
+  agent exits, and their failures are logged, not fatal. clai exits with
+  the agent's code (or a failing pre-hook's).
+
+Options:
+  -l, --list-agents   List agents with a clai.d/<agent>/ hook directory
+                      found on the walk from $PWD to $HOME, sorted.
+  -h, --help          Show this help and exit.
+
+Hook environment:
+  CLAI_AGENT  agent name              CLAI_STAGE  pre | post
+  CLAI_CWD    launch directory        CLAI_EXIT   agent exit code (post only)
+  CLAI_ARGS   agent argv, shell-quoted
 EOF
 }
 
@@ -151,6 +212,7 @@ main() {
     fi
     case "$1" in
         -h|--help) usage; exit 0 ;;
+        -l|--list-agents) run_list_agents; exit 0 ;;
     esac
     local agent="$1"; shift
     launch_agent "${agent}" "$@"

--- a/test/smoketest_clai/09_help_flag.sh
+++ b/test/smoketest_clai/09_help_flag.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# 09_help_flag.sh
+# Given no agent, when clai is invoked with --help or -h, then it prints usage
+# (covering --list-agents) and exits 0 without launching anything.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    init_scenario "09_help_flag"
+
+    local flag out rc
+    for flag in --help -h; do
+        rc=0
+        out="$(run_clai workdir "${flag}")" || rc=$?
+        if (( rc != 0 )); then
+            echo "FAIL: clai ${flag} exited ${rc}" >&2; return 1
+        fi
+        if ! grep -q 'Usage:' <<<"${out}"; then
+            echo "FAIL: clai ${flag} output missing Usage:" >&2
+            echo "${out}" >&2; return 1
+        fi
+        if ! grep -q -- '--list-agents' <<<"${out}"; then
+            echo "FAIL: clai ${flag} output does not mention --list-agents:" >&2
+            echo "${out}" >&2; return 1
+        fi
+    done
+}
+
+main "$@"

--- a/test/smoketest_clai/10_list_agents.sh
+++ b/test/smoketest_clai/10_list_agents.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# 10_list_agents.sh
+# Given clai.d/<agent>/ directories planted across $HOME and a nested level,
+# when clai --list-agents runs, then every configured agent is listed once,
+# sorted, even when an agent appears at more than one level.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+noop_hook=$'#!/usr/bin/env bash\n:\n'
+
+main() {
+    init_scenario "10_list_agents"
+
+    # Global agents at $HOME.
+    write_hook "${FAKE_HOME}" claude pre 10-mark "${noop_hook}"
+    write_hook "${FAKE_HOME}" gemini pre 10-mark "${noop_hook}"
+    # Project level: re-declare claude (so it spans two levels) and add codex.
+    write_hook "${FAKE_HOME}/proj" claude post 10-mark "${noop_hook}"
+    write_hook "${FAKE_HOME}/proj" codex pre 10-mark "${noop_hook}"
+
+    local out rc=0
+    out="$(run_clai proj --list-agents)" || rc=$?
+    if (( rc != 0 )); then
+        echo "FAIL: clai --list-agents exited ${rc}" >&2; return 1
+    fi
+
+    local expected
+    expected=$'claude\ncodex\ngemini'
+    if [[ "${out}" != "${expected}" ]]; then
+        echo "FAIL: agent list mismatch" >&2
+        echo "expected:" >&2; echo "${expected}" >&2
+        echo "got:" >&2; echo "${out}" >&2
+        return 1
+    fi
+
+    # -l is the documented short form and must behave identically.
+    local short rc2=0
+    short="$(run_clai proj -l)" || rc2=$?
+    if (( rc2 != 0 )) || [[ "${short}" != "${expected}" ]]; then
+        echo "FAIL: clai -l disagrees with --list-agents:" >&2
+        echo "${short}" >&2; return 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Quick fix to `clai`: a real `--help`, and a way to list configured agents.

- **`--help` / `-h`** — already routed to `usage()`, but `usage()` was a
  two-line stub. It now documents all three invocation forms, the overlay-hook
  model, the options, and the hook environment.
- **`--list-agents` / `-l`** (new) — prints, sorted and de-duplicated, every
  agent that has a `clai.d/<agent>/` directory on the `$PWD`→`$HOME` walk. Bare
  names to stdout (pipeable); a "none found" note to stderr; exits 0 either way.
- **Refactor** — extracted `walk_base_dirs()` so the level-walk (including the
  "not under `$HOME`" rule) is shared by `walk_levels()` (existing hook
  discovery, behavior unchanged) and the new `list_agents()`.

## Tests

- `test/smoketest_clai/09_help_flag.sh` — `--help`/`-h` exit 0 and emit usage
  mentioning `--list-agents`.
- `test/smoketest_clai/10_list_agents.sh` — agents planted across `$HOME` and a
  nested level; asserts the list is sorted, de-duplicated (an agent spanning
  two levels appears once), and that `-l` matches `--list-agents`.
- Full suite: **10/10 passing.**

## Docs

- `CLAI.DESIGN.md` Invocation section now documents `--list-agents` and `--help`.
- Fixed a stale path reference: `test/clai/` → `test/smoketest_clai/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
