### PR TITLE
feat(lmde): implement tech radar skill and initial audit

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,6 +7,8 @@ conservatively. Don't read them all in; they'll flood your context.
 
 Ingest the whole relevant file (and follow it) at the moment a task
 starts that maps to one:
+- Designing or evaluating LMDE tech (a new CLI tool, language, local
+  service, or AI tooling change) → SKILL.TECH_RADAR.md.
 - Writing or reviewing tests → TESTING.md.
 - About to push code, create or review a PR, reply to PR feedback, or
   subscribe to PR activity → GITHUB.md. The trigger is the push/review

--- a/TODO_PLAN.md
+++ b/TODO_PLAN.md
@@ -38,7 +38,7 @@ The gadmin Issues subsystem shipped a working v0 skeleton (grammar, aggregator, 
 - [x] Task LMDE1: **Implement Local Registry sync script.** Create `lmde/components/registry/sync.sh` and `images.txt` to mirror vetted, digest-pinned images to `localhost:5001`.
 - [x] Task LMDE2: **Bootstrap Observability Stack.** Create `lmde/components/observability/setup.sh` and `kind-config.yaml` to deploy OTel, Prometheus, and Grafana with host-path persistence.
 - [x] Task LMDE3: **Observability Smoke Tests.** Create `test/smoketest_lmde_observability/` to verify the end-to-end telemetry pipeline (OTLP -> Prometheus -> Grafana).
-- [ ] Task LMDE4: **Implement LMDE Tech Radar.** Create `prompts/SKILL.TECH_RADAR.md` based on the design doc, add the `CLAUDE.md` ingest hook, and perform the initial backfill of "Adopted" and "Hold" tech.
+- [x] Task LMDE4: **Implement LMDE Tech Radar.** Create `prompts/SKILL.TECH_RADAR.md` based on the design doc, add the `CLAUDE.md` ingest hook, and perform the initial backfill of "Adopted" and "Hold" tech.
 
 ### Terminal UX
 

--- a/prompts/SKILL.TECH_RADAR.md
+++ b/prompts/SKILL.TECH_RADAR.md
@@ -1,0 +1,70 @@
+# SKILL: LMDE Tech Radar
+
+> Purpose: Snapshot of the LMDE's current tech choices and their rationale, to guide additions and prevent drift.
+> When to use: Before adding tooling, services, or languages to the LMDE.
+> Scope: tds-utils (the LMDE) only. Per-project stacks live in template-tools.
+> Update Discipline: MAINTAINED BY THE HUMAN. AI agents audit and propose changes, but do not commit edits to this file without explicit human approval.
+
+---
+
+## When to Invoke This Skill
+- About to add a new CLI tool, language, or local service to the LMDE.
+- Considering replacing or removing existing LMDE tech.
+- Evaluating a new AI/agent tool, MCP server, or skill pattern.
+- Onboarding a new machine and questioning a default.
+- **NOT** for per-project tech (e.g., choice of database for a specific app).
+
+## Adopt -- Current Platform Standards
+
+These technologies are the foundational components of the Local Managed Developer Environment (LMDE). They form a stable contract that other projects can rely upon.
+
+### Languages & Runtimes
+- **zsh**: Primary shell on macOS. Chosen for rich interactive features and macOS defaults.
+- **bash**: Primary shell on Linux. Chosen for ubiquity and standard automation.
+- **Node.js (MJS)**: Used for sophisticated environment orchestration (e.g., `gadmin`). Chosen for asynchronous I/O and GitHub API ecosystem.
+- **Python 3**: Used for data processing and search tasks (e.g., `log-hoarder`). Chosen for standard library and text handling.
+- **Go**: Used for systems-level CLI tools. Chosen for static binaries and performance.
+
+### Core Infrastructure
+- **1Password CLI (op)**: Source of truth for secrets and identity.
+- **NATS**: Distributed message bus for local service inter-op. Standardized on `localhost:4222`.
+- **Caddy**: Local reverse proxy and TLS terminator.
+- **dnsmasq**: Local DNS orchestration for `.localhost` and internal discovery.
+- **Local Registry**: Secure container mirror on `localhost:5001`.
+
+### Editor & Multiplexer
+- **Emacs**: The primary digital workspace. Extensively customized via `init.el`.
+- **tmux**: Standard terminal multiplexing and session persistence.
+
+### AI & Agents
+- **Ollama**: Local LLM inference server.
+- **remollama**: Remote orchestration and proxying for Ollama.
+- **OpenTelemetry (OTel)**: Standardized destination for agent metrics and traces.
+
+### Development Platforms
+- **kind**: Kubernetes in Docker for local cluster orchestration. Standardized boundary for complex services (like Observability).
+
+---
+
+## Trial -- Testing in Limited Scope
+- **MCP (Model Context Protocol)**: Evaluating for standardized agent tool-use.
+
+---
+
+## Assess -- Researching / Observing
+- **sqlite-vec**: Potential replacement for heavier embedding search frameworks in `log-hoarder`.
+
+---
+
+## Hold -- Avoid / Deprecated
+- **bash on macOS**: Deprecated in favor of `zsh`.
+- **GNU Coreutils on macOS**: Use BSD-first syntax to maintain macOS portability.
+- **Hardcoded Secrets**: All secrets must go through `op` or Kubernetes Secrets; never checked into the repo.
+- **Docker for Simple Services**: Prefer running services natively or in `kind` if they require K8s; avoid standalone `docker-compose` for permanent environment services.
+- **Perl**: Legacy. Only used in `ipscan.pl`. No new development.
+
+---
+
+## Decisions Log
+- **2026-05-21**: Formalized LMDE architecture and Observability stack.
+- **2026-05-18**: Initial Tech Radar design conversation (see `docs/design/WIP.TECH_RADAR.DESIGN.md`).


### PR DESCRIPTION
## Overview
This PR implements the **LMDE Tech Radar Skill** and performs the initial backfill of the project's technology stack. It formalizes the platform standards (Adopt), experimental tech (Trial/Assess), and deprecated tools (Hold) as defined in the architectural blueprint.

## Accomplishments
- **Created `prompts/SKILL.TECH_RADAR.md`**: A living document of the LMDE tech choices and their rationale.
- **Backfilled Initial Audit**: Documented the core languages (zsh, Python, Go, Node), infrastructure (NATS, Caddy, OTel), and tools (Emacs, tmux) currently in use.
- **Updated `AGENT.md`**: Added an ingest hook to ensure future AI agents load the Tech Radar when designing or evaluating local tech.
- **Marked Task LMDE4 Completed**: Updated `TODO_PLAN.md`.

## Rationale
The Tech Radar serves as a stable decision history for the digital kernel that is `tds-utils`. It ensures that both humans and AI agents have clear guidance on what technologies are supported and why others have been rejected.

## Next Steps
- Finalize the backfill based on human review.
- Integrate the radar into the per-project `template-tools` (future work).