### PR TITLE
feat(clai): route AI coding agents through the clai launcher

### DIFF
--- a/git-config/dot.gitconfig
+++ b/git-config/dot.gitconfig
@@ -27,3 +27,8 @@
 	helper = !/opt/homebrew/bin/gh auth git-credential
 [init]
 	defaultBranch = main
+[naatm "mirror"]
+	enabled = true
+	bucket = naatm-git-mirror-stumpf
+	profile = naatm-dr
+	endpoint = https://f355ce2de8e98188390332bfc1f8c24c.r2.cloudflarestorage.com

--- a/macos/dot.alias
+++ b/macos/dot.alias
@@ -29,3 +29,13 @@ alias bit-tunnel="ssh -L 5678:127.0.0.1:5678 stumpf@100.125.95.68"
 
 # goldfish — recent-work report across repos
 alias gf=goldfish
+
+# Route AI coding agents through clai (overlay hooks + OpenTelemetry env).
+# Interactive shells only — scripts that call these binaries directly are
+# unaffected. clai launches the real agent via subprocess, which does not
+# inherit these aliases, so there is no recursion. For a raw run, bypass
+# with `command <agent>` or `\<agent>`.
+alias claude='clai claude'
+alias gemini='clai gemini'
+alias codex='clai codex'
+alias opencode='clai opencode'

--- a/macos/dot.zshrc
+++ b/macos/dot.zshrc
@@ -84,6 +84,13 @@ source ~/workplace/lab54/grubsta/scripts/completions/grubsta-completions.zsh
 # Path updates
 export PATH="/Users/stumpf/.antigravity/antigravity/bin:$PATH"
 
+# Normalize PATH: collapse duplicate entries, and ensure ~/.local/bin (the
+# uv-installed tools — clai, designomatic, crmagic) precedes tds-utils/bin so
+# the installed Python clai (with OpenTelemetry) wins over the legacy
+# bin/clai script. Must stay after every PATH mutation above.
+typeset -U path
+path=("$HOME/.local/bin" $path)
+
 # log-hoarder: semantic search widget (ctrl-x s)
 if [[ -f ~/workplace/tds-utils/macos/dot.zsh_log_search ]]; then
     source ~/workplace/tds-utils/macos/dot.zsh_log_search


### PR DESCRIPTION
## Summary

Two `tds-utils` environment changes.

### `feat(clai)` — route AI coding agents through clai (c773fb1)

`claude`, `gemini`, `codex`, and `opencode` now alias to `clai <agent>`, so
the overlay-hook + OpenTelemetry launcher is used by muscle memory.

- `macos/dot.alias` — the four aliases. Interactive shells only; clai
  launches the real agent via a subprocess that does **not** inherit shell
  aliases, so there is no recursion. Raw run: `command <agent>` or
  `\<agent>`.
- `macos/dot.zshrc` — normalize PATH (`typeset -U path`) and prepend
  `~/.local/bin`, so the installed Python clai (with OpenTelemetry) wins
  over the legacy `bin/clai` script. Placed after every PATH mutation and
  before the tmux re-exec, so every shell is normalized.

### `chore(git)` — mirror GitHub pushes to an R2 bucket (2d44a37)

Adds a `[naatm "mirror"]` section to `git-config/dot.gitconfig` targeting
the `naatm-git-mirror-stumpf` R2 bucket, so pushes are mirrored off GitHub
as an outage backup.

## Notes

- Cut fresh from `master`. The work was first committed onto the
  post-merge `claude/feat/lmde-grafana-dashboards` branch; these two commits
  were cherry-picked onto a clean branch so the PR diff is exactly the three
  files below — no already-merged grafana noise.
- Diff: `git-config/dot.gitconfig` (+5), `macos/dot.alias` (+10),
  `macos/dot.zshrc` (+7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
