### PR TITLE
docs(radar,lmde): adopt Chrome for Testing as per-project pattern

### DIFF
--- a/lmde/LMDE.md
+++ b/lmde/LMDE.md
@@ -50,3 +50,9 @@ Any project running within this environment can assume the existence and availab
 - **Individual Tooling**: `fzf`, `jq`, `sed` are utilities, not architectural components.
 - **Personal Configs**: Emacs `init.el`, `dot.bashrc`, and themes are personal preferences, not platform dependencies.
 - **Project-Specific Services**: Databases or services that only one project needs.
+- **Per-Project Browser Automation**: Chrome for Testing (used by some
+  projects to give an agent driveable Chrome control without touching
+  the user's main browser) is intentionally **per-project**, not LMDE.
+  Each project installs its own under `~/.cache/<project>-cft/` with its
+  own version, profile, and extension loadout. See
+  `@nine-at-a-time-media/prompts` `SKILL.CHROME_MCP.md` for the pattern.

--- a/prompts/SKILL.TECH_RADAR.md
+++ b/prompts/SKILL.TECH_RADAR.md
@@ -40,16 +40,21 @@ These technologies are the foundational components of the Local Managed Develope
 - **Ollama**: Local LLM inference server.
 - **remollama**: Remote orchestration and proxying for Ollama.
 - **OpenTelemetry (OTel)**: Standardized destination for agent metrics and traces.
-- **Chrome for Testing (via `chrome-devtools-mcp`)**: Stand-alone Chrome
-  for giving an agent driveable control of a browser without enabling
-  remote debugging on the user's main Chrome. Per-project install under
-  `~/.cache/<project>-cft/`; **not** part of the LMDE contract — each
-  project installs its own. See `@nine-at-a-time-media/prompts`
-  `SKILL.CHROME_MCP.md` for the wiring pattern. First adopted in `ai-gm`
-  Phase 0.5.
 
 ### Development Platforms
 - **kind**: Kubernetes in Docker for local cluster orchestration. Standardized boundary for complex services (like Observability).
+
+### Per-Project Patterns (Recommended, not LMDE contract)
+Tooling patterns adopted for use *within* projects rather than as LMDE
+platform components. Each project installs its own; this section
+documents the recommended approach so it isn't reinvented per repo.
+
+- **Chrome for Testing (via `chrome-devtools-mcp`)**: Stand-alone
+  Chromium binary for giving an agent driveable control of a browser
+  without enabling remote debugging on the user's main Chrome.
+  Per-project install under `~/.cache/<project>-cft/`. See
+  `@nine-at-a-time-media/prompts` `SKILL.CHROME_MCP.md` for the wiring
+  pattern. First adopted in `ai-gm` Phase 0.5.
 
 ---
 

--- a/prompts/SKILL.TECH_RADAR.md
+++ b/prompts/SKILL.TECH_RADAR.md
@@ -40,6 +40,13 @@ These technologies are the foundational components of the Local Managed Develope
 - **Ollama**: Local LLM inference server.
 - **remollama**: Remote orchestration and proxying for Ollama.
 - **OpenTelemetry (OTel)**: Standardized destination for agent metrics and traces.
+- **Chrome for Testing (via `chrome-devtools-mcp`)**: Stand-alone Chrome
+  for giving an agent driveable control of a browser without enabling
+  remote debugging on the user's main Chrome. Per-project install under
+  `~/.cache/<project>-cft/`; **not** part of the LMDE contract — each
+  project installs its own. See `@nine-at-a-time-media/prompts`
+  `SKILL.CHROME_MCP.md` for the wiring pattern. First adopted in `ai-gm`
+  Phase 0.5.
 
 ### Development Platforms
 - **kind**: Kubernetes in Docker for local cluster orchestration. Standardized boundary for complex services (like Observability).
@@ -66,5 +73,12 @@ These technologies are the foundational components of the Local Managed Develope
 ---
 
 ## Decisions Log
+- **2026-05-23**: Adopted Chrome for Testing (via `chrome-devtools-mcp`)
+  as the per-project pattern for agent-driven browser control. Rationale:
+  Chrome 142+ silently disabled `--load-extension` for branded Chrome
+  under `--enable-automation`; CfT is exempt. Pattern lives in
+  `@nine-at-a-time-media/prompts` `SKILL.CHROME_MCP.md`; not LMDE
+  contract because each project gets its own profile, version, and
+  extension loadout.
 - **2026-05-21**: Formalized LMDE architecture and Observability stack.
 - **2026-05-18**: Initial Tech Radar design conversation (see `docs/design/WIP.TECH_RADAR.DESIGN.md`).


### PR DESCRIPTION
## Summary

Documents the Chrome-for-Testing pattern (used by `chrome-devtools-mcp` to give an AI coding agent driveable control of a browser without enabling remote debugging on the user's main Chrome) on the tech radar and clarifies why it is intentionally NOT part of the LMDE contract.

## Changes

- **`prompts/SKILL.TECH_RADAR.md`**
  - New entry under **Adopt → AI & Agents**: "Chrome for Testing (via `chrome-devtools-mcp`)" with explicit per-project (not LMDE) framing.
  - **Decisions Log** entry for `2026-05-23` with rationale (Chrome 142+ removed `--load-extension` under `--enable-automation`; CfT is exempt).
- **`lmde/LMDE.md`**
  - New **Non-Goals** entry: per-project browser automation is intentionally NOT in the LMDE contract; each project installs its own CfT under `~/.cache/<project>-cft/`.

## Related

- Pattern itself lives in `@nine-at-a-time-media/prompts` `SKILL.CHROME_MCP.md` — see template-tools [PR #20](https://github.com/Nine-At-A-Time-Media/template-tools/pull/20).
- First adoption in ai-gm Phase 0.5 — [PR #8](https://github.com/Nine-At-A-Time-Media/ai-gm/pull/8).

## Test plan

- [ ] Render-check both files; structure remains intact.
- [ ] Confirm the "AI & Agents" placement in TECH_RADAR is the right home (vs. a new "Browser Automation" subsection).
- [ ] Confirm the LMDE.md "Non-Goals" entry's tone matches the existing items.

## Note on human-maintained file

`SKILL.TECH_RADAR.md` is marked "MAINTAINED BY THE HUMAN. AI agents audit and propose changes, but do not commit edits to this file without explicit human approval." User granted explicit permission for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)