### PR TITLE
feat(goldfish): repo-zoom mode and LMDE backplane plan

### DIFF
--- a/TODO_PLAN.md
+++ b/TODO_PLAN.md
@@ -41,6 +41,8 @@ The gadmin Issues subsystem shipped a working v0 skeleton (grammar, aggregator, 
 - [ ] Task LMDE10: **Events: Grafana datasource + bootstrap + verify.** Add the Grafana Loki datasource, install Loki in `setup.sh`, and smoke-test an OTLP event end to end.
   - Note: the events pipeline stays inert until clai sets `OTEL_LOGS_EXPORTER=otlp` (in `ai-tools`, not this repo) -- coordinate before declaring LMDE10 done.
 - [ ] Task LMDE11: **Stack-health Grafana dashboard.** Add a Grafana dashboard monitoring the obs stack itself -- CPU, memory, storage, restarts/errors per component (prometheus, grafana, otel-collector, loki, ingress-nginx). Dashboard JSON + ConfigMap; no new infra; can land before LMDE7-10.
+- [ ] Task LMDE12: **NATS-in-kind: design.** Draft `docs/design/LMDE-BACKPLANE.DESIGN.md` -- move the LMDE backplane (starting with NATS, then audit each other Adopted component against the residency rule in `lmde/LMDE.md`) into the kind cluster behind LMDE5's ingress-nginx + `*.lmde.localhost`, so kind-sandboxed coding agents reach the same bus as Mac-local agents. Decide: NATS server in-cluster vs. exposing host NATS via ingress; auth model (anonymous loopback today vs. per-agent creds); how `gadmin` and other clients resolve the bus address from inside vs. outside the cluster; which components actually need to move (Caddy/dnsmasq/registry sit at the edge or feed kind and may stay out). Update the `lmde/LMDE.md` Contract once the design lands.
+- [ ] Task LMDE13: **NATS-in-kind: implement.** Add `lmde/components/nats/` (kind manifest + `setup.sh`), pin the image digest in `lmde/components/registry/images.txt`, register `nats.lmde.localhost` via the LMDE5 ingress helper, and add a `test/smoketest_lmde_nats/` smoke that pub/subs from both the host and an in-cluster pod. Depends on LMDE12.
 
 ### Terminal UX
 
@@ -138,6 +140,7 @@ The gadmin Issues subsystem shipped a working v0 skeleton (grammar, aggregator, 
   - **G7** `--include-org` / `--exclude-org`: repeatable filter flags, exclude wins over include.
   - **G4 (Linux scaffolding)**: hermetic `test/smoketest_goldfish/` bash suite, 6 scenarios, all green on Linux. macOS verification (`lsof` path) remains open as the G4 entry above.
 - [x] Tasks G4 (macOS half) + G8: Verified goldfish on macOS (6/6 smoketests green, real-run JSON output sane). Added `bin/goldfish` symlink and `gf` alias in `macos/dot.alias`.
+- [x] Task G9: **Repo-zoom mode (`gf <repo>`).** Added a positional repo-name arg that renders a one-repo vertical summary instead of the cross-repo table -- recent commits, open PR list with draft state, agents in cwd, full open-task list from TODO_PLAN.md, dirty/ahead state. Basename resolution against the clones cache (`gf tds-utils` finds `9atatimer/tds-utils`); pass `owner/name` to zoom an uncloned repo. New `ZoomData`/`CommitSummary`/`PRSummary` core types with 12 unit tests + `test/smoketest_goldfish/07_repo_zoom.sh`.
 
 ### LMDE (Local Managed Developer Environment)
 

--- a/goldfish/core.py
+++ b/goldfish/core.py
@@ -49,6 +49,31 @@ class RepoRow:
 
 
 @dataclass(frozen=True, slots=True)
+class CommitSummary:
+    sha: str
+    subject: str
+
+
+@dataclass(frozen=True, slots=True)
+class PRSummary:
+    number: int
+    title: str
+    author: str
+    is_draft: bool
+
+
+@dataclass(frozen=True, slots=True)
+class ZoomData:
+    name: str
+    github: GithubInfo | None
+    local: LocalInfo | None
+    recent_commits: tuple[CommitSummary, ...] = field(default_factory=tuple)
+    open_prs: tuple[PRSummary, ...] = field(default_factory=tuple)
+    agents: tuple[AgentSession, ...] = field(default_factory=tuple)
+    open_tasks: tuple[str, ...] = field(default_factory=tuple)
+
+
+@dataclass(frozen=True, slots=True)
 class GitDirtyState:
     branch: str
     is_dirty: bool
@@ -73,6 +98,20 @@ def parse_todo_plan(text: str) -> str | None:
             continue
         return task
     return None
+
+
+def parse_todo_plan_all(text: str) -> list[str]:
+    """Return every unchecked task in source order, skipping struck-through ones."""
+    out: list[str] = []
+    for raw in text.splitlines():
+        m = _TODO_LINE.match(raw)
+        if not m:
+            continue
+        task = m.group(1).strip()
+        if _STRUCK.match(task):
+            continue
+        out.append(task)
+    return out
 
 
 def parse_gh_repo_list(raw: str) -> list[GithubInfo]:
@@ -450,6 +489,92 @@ def _local_to_jsonable(l: LocalInfo | None) -> dict | None:
         "last_commit_at": l.last_commit_at.isoformat() if l.last_commit_at else None,
         "next_task": l.next_task,
     }
+
+
+# --- Zoom (G9): single-repo activity summary --------------------------------
+
+def resolve_repo_name(query: str, *, known: Iterable[str]) -> list[str]:
+    """Resolve a user-typed repo query against known `owner/name` keys.
+
+    1. Exact match wins outright -- if the query is in `known`, return just it.
+    2. Otherwise, treat the query as a basename and match case-insensitively
+       against the segment after the last `/` in each key.
+    3. Returns matches sorted; empty list = no match; len > 1 = ambiguous.
+    """
+    known_set = set(known)
+    if query in known_set:
+        return [query]
+    needle = query.lower()
+    matches = [
+        name for name in known_set
+        if name.rsplit("/", 1)[-1].lower() == needle
+    ]
+    return sorted(matches)
+
+
+def _fmt_dt(dt: datetime | None) -> str:
+    if dt is None:
+        return "—"
+    return dt.astimezone(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def format_zoom(data: ZoomData) -> str:
+    """Render a single-repo activity summary as a vertical text block."""
+    lines: list[str] = [data.name, "=" * len(data.name), ""]
+
+    lines.append("GitHub:")
+    if data.github is None:
+        lines.append("  (no GitHub data)")
+    else:
+        lines.append(f"  pushed:    {_fmt_dt(data.github.pushed_at)}")
+        lines.append(f"  open PRs:  {data.github.open_pr_count}")
+    lines.append("")
+
+    if data.local is None:
+        lines.append("Local: (not cloned)")
+    else:
+        lines.append(f"Local: {data.local.path}")
+        lines.append(f"  branch:       {data.local.branch or '—'}")
+        lines.append(f"  dirty:        {'yes' if data.local.is_dirty else 'no'}")
+        lines.append(
+            f"  ahead/behind: {data.local.ahead} / {data.local.behind}"
+        )
+        lines.append(f"  last commit:  {_fmt_dt(data.local.last_commit_at)}")
+    lines.append("")
+
+    lines.append("Recent commits:")
+    if not data.recent_commits:
+        lines.append("  (none)")
+    else:
+        for c in data.recent_commits:
+            lines.append(f"  {c.sha:<8}  {c.subject}")
+    lines.append("")
+
+    lines.append("Open PRs:")
+    if not data.open_prs:
+        lines.append("  (none)")
+    else:
+        for pr in data.open_prs:
+            marker = " (draft)" if pr.is_draft else ""
+            lines.append(f"  #{pr.number}{marker}  {pr.title}  -- @{pr.author}")
+    lines.append("")
+
+    lines.append("Agents:")
+    if not data.agents:
+        lines.append("  (none)")
+    else:
+        for a in sorted(data.agents, key=lambda x: x.pid):
+            lines.append(f"  {a.pid:>7}  {a.name}")
+    lines.append("")
+
+    lines.append(f"Open tasks (TODO_PLAN.md, {len(data.open_tasks)}):")
+    if not data.open_tasks:
+        lines.append("  (none)")
+    else:
+        for t in data.open_tasks:
+            lines.append(f"  - {t}")
+
+    return "\n".join(lines)
 
 
 # --- Formatter ---------------------------------------------------------------

--- a/goldfish/core.py
+++ b/goldfish/core.py
@@ -497,18 +497,23 @@ def resolve_repo_name(query: str, *, known: Iterable[str]) -> list[str]:
     """Resolve a user-typed repo query against known `owner/name` keys.
 
     1. Exact match wins outright -- if the query is in `known`, return just it.
-    2. Otherwise, treat the query as a basename and match case-insensitively
+    2. If the query contains `/`, treat it as a full `owner/name` and match
+       case-insensitively against each key.
+    3. Otherwise, treat the query as a basename and match case-insensitively
        against the segment after the last `/` in each key.
-    3. Returns matches sorted; empty list = no match; len > 1 = ambiguous.
+    4. Returns matches sorted; empty list = no match; len > 1 = ambiguous.
     """
     known_set = set(known)
     if query in known_set:
         return [query]
     needle = query.lower()
-    matches = [
-        name for name in known_set
-        if name.rsplit("/", 1)[-1].lower() == needle
-    ]
+    if "/" in query:
+        matches = [name for name in known_set if name.lower() == needle]
+    else:
+        matches = [
+            name for name in known_set
+            if name.rsplit("/", 1)[-1].lower() == needle
+        ]
     return sorted(matches)
 
 

--- a/goldfish/goldfish
+++ b/goldfish/goldfish
@@ -306,6 +306,10 @@ def run_zoom(query: str, args: argparse.Namespace) -> int:
                 open_tasks = tuple(parse_todo_plan_all(todo_path.read_text()))
             except (OSError, UnicodeDecodeError):
                 open_tasks = ()
+    elif args.fetch_remote_todos:
+        text = fetch_remote_todo_plan(name)
+        if text:
+            open_tasks = tuple(parse_todo_plan_all(text))
 
     data = ZoomData(
         name=name,

--- a/goldfish/goldfish
+++ b/goldfish/goldfish
@@ -23,11 +23,14 @@ sys.path.insert(0, str(HERE))
 from core import (  # noqa: E402
     GithubInfo,
     RepoRow,
+    ZoomData,
     apply_blacklist,
     apply_org_filter,
     format_processes,
     format_table,
+    format_zoom,
     is_actionable,
+    resolve_repo_name,
     rows_to_json,
     sort_rows,
 )
@@ -39,6 +42,9 @@ from shell import (  # noqa: E402
     find_local_clones,
     gh_list_repos,
     gh_open_pr_counts,
+    gh_prs_for_repo,
+    gh_pushed_at,
+    git_recent_commits,
     have,
     inspect_local,
     load_blacklist,
@@ -49,7 +55,7 @@ from shell import (  # noqa: E402
     save_cached_clones,
     summarize_with_llm,
 )
-from core import parse_todo_plan  # noqa: E402
+from core import parse_todo_plan, parse_todo_plan_all  # noqa: E402
 
 
 # --- Action functions --------------------------------------------------------
@@ -241,6 +247,79 @@ def _build_row(
     return RepoRow(name=name, github=github_info, local=local, agents=repo_agents)
 
 
+def run_zoom(query: str, args: argparse.Namespace) -> int:
+    """Render a one-repo activity summary instead of the cross-repo table."""
+    config = load_config()
+    cached = None if args.refresh else load_cached_clones()
+    use_cache = cached is not None and cached_clones_fresh(cached)
+    if use_cache:
+        clones = dict(cached.clones)
+    else:
+        clones = find_local_clones(resolve_roots(config))
+        save_cached_clones(clones)
+
+    candidates = set(clones)
+    if "/" in query:
+        candidates.add(query)
+    matches = resolve_repo_name(query, known=candidates)
+
+    if not matches:
+        print(
+            f"goldfish: no repo matching '{query}'. "
+            f"Pass owner/name to zoom an uncloned repo, or --refresh to rescan.",
+            file=sys.stderr,
+        )
+        return 1
+    if len(matches) > 1:
+        print(
+            f"goldfish: '{query}' is ambiguous; matches: {', '.join(matches)}",
+            file=sys.stderr,
+        )
+        return 1
+    name = matches[0]
+    workdir = clones.get(name)
+
+    agents_known = set(config.get("agents", []))
+
+    with ThreadPoolExecutor(max_workers=5) as ex:
+        f_pushed = ex.submit(gh_pushed_at, name)
+        f_prs = ex.submit(gh_prs_for_repo, name)
+        f_commits = ex.submit(git_recent_commits, workdir) if workdir else None
+        f_local = ex.submit(inspect_local, workdir) if workdir else None
+        f_agents = (
+            ex.submit(running_agents, agents_known, {name: workdir})
+            if workdir else None
+        )
+        pushed_at = f_pushed.result()
+        prs = f_prs.result()
+        commits = tuple(f_commits.result()) if f_commits else ()
+        local = f_local.result() if f_local else None
+        agents = tuple(f_agents.result()) if f_agents else ()
+
+    github = GithubInfo(name=name, pushed_at=pushed_at, open_pr_count=len(prs))
+
+    open_tasks: tuple[str, ...] = ()
+    if workdir:
+        todo_path = workdir / "TODO_PLAN.md"
+        if todo_path.exists():
+            try:
+                open_tasks = tuple(parse_todo_plan_all(todo_path.read_text()))
+            except (OSError, UnicodeDecodeError):
+                open_tasks = ()
+
+    data = ZoomData(
+        name=name,
+        github=github,
+        local=local,
+        recent_commits=commits,
+        open_prs=tuple(prs),
+        agents=agents,
+        open_tasks=open_tasks,
+    )
+    print(format_zoom(data))
+    return 0
+
+
 def run_manage_blacklist(args: argparse.Namespace) -> int:
     """Toggle blacklist entries interactively, then save and exit.
 
@@ -372,6 +451,11 @@ def run(argv: list[str]) -> int:
         description="At-a-glance report of recent work across your github repos.",
     )
     parser.add_argument(
+        "repo", nargs="?", default=None,
+        help="Optional repo name or owner/name. When set, render a single-repo "
+             "activity summary instead of the cross-repo table.",
+    )
+    parser.add_argument(
         "--fetch-remote-todos", action="store_true",
         help="If a repo has no local clone, fetch TODO_PLAN.md from GitHub.",
     )
@@ -421,6 +505,9 @@ def run(argv: list[str]) -> int:
 
     if args.manage_blacklist:
         return run_manage_blacklist(args)
+
+    if args.repo is not None:
+        return run_zoom(args.repo, args)
 
     if not have("gh"):
         sys.stderr.write(

--- a/goldfish/shell.py
+++ b/goldfish/shell.py
@@ -385,7 +385,7 @@ def _llm_candidates() -> list[list[str]]:
 
 
 def git_recent_commits(workdir: Path, *, n: int = 8) -> list[CommitSummary]:
-    """Return the last `n` commits as (short_sha, subject) pairs. Empty on error."""
+    """Return the last `n` commits as CommitSummary records. Empty list on error."""
     raw = _run(
         ["git", "log", f"-{n}", "--format=%h%x09%s"],
         cwd=str(workdir),

--- a/goldfish/shell.py
+++ b/goldfish/shell.py
@@ -20,9 +20,11 @@ from pathlib import Path
 from core import (
     AgentSession,
     ClonesCache,
+    CommitSummary,
     GithubInfo,
     LocalInfo,
     GitDirtyState,
+    PRSummary,
     enclosing_repo,
     first_meaningful_line,
     format_marker_state,
@@ -379,6 +381,72 @@ def _llm_candidates() -> list[list[str]]:
     if have("ollama"):
         model = os.environ.get("GOLDFISH_OLLAMA_MODEL", "llama3.2")
         out.append(["ollama", "run", model, LLM_PROMPT])
+    return out
+
+
+def git_recent_commits(workdir: Path, *, n: int = 8) -> list[CommitSummary]:
+    """Return the last `n` commits as (short_sha, subject) pairs. Empty on error."""
+    raw = _run(
+        ["git", "log", f"-{n}", "--format=%h%x09%s"],
+        cwd=str(workdir),
+        timeout=5.0,
+    )
+    out: list[CommitSummary] = []
+    for line in raw.splitlines():
+        if "\t" not in line:
+            continue
+        sha, subject = line.split("\t", 1)
+        out.append(CommitSummary(sha=sha, subject=subject))
+    return out
+
+
+def gh_pushed_at(name_with_owner: str) -> datetime | None:
+    """Fetch the repo's pushedAt timestamp via `gh repo view`."""
+    if not have("gh"):
+        return None
+    raw = _run(
+        ["gh", "repo", "view", name_with_owner, "--json", "pushedAt"],
+        timeout=10.0,
+    )
+    if not raw.strip():
+        return None
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    pushed = data.get("pushedAt")
+    if not isinstance(pushed, str):
+        return None
+    return _parse_iso_safe(pushed)
+
+
+def gh_prs_for_repo(name_with_owner: str) -> list[PRSummary]:
+    """List open PRs for one repo via `gh pr list`. Empty list on any failure."""
+    if not have("gh"):
+        return []
+    raw = _run([
+        "gh", "pr", "list",
+        "-R", name_with_owner,
+        "--state", "open",
+        "--json", "number,title,author,isDraft",
+        "--limit", "50",
+    ], timeout=15.0)
+    if not raw.strip():
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    out: list[PRSummary] = []
+    for entry in data:
+        number = entry.get("number")
+        title = entry.get("title") or ""
+        author = (entry.get("author") or {}).get("login") or "?"
+        is_draft = bool(entry.get("isDraft"))
+        if isinstance(number, int):
+            out.append(PRSummary(
+                number=number, title=title, author=author, is_draft=is_draft,
+            ))
     return out
 
 

--- a/goldfish/test_core.py
+++ b/goldfish/test_core.py
@@ -10,9 +10,12 @@ from pathlib import Path
 
 from core import (
     AgentSession,
+    CommitSummary,
     GithubInfo,
     LocalInfo,
+    PRSummary,
     RepoRow,
+    ZoomData,
     apply_blacklist,
     apply_org_filter,
     enclosing_repo,
@@ -20,6 +23,7 @@ from core import (
     format_marker_state,
     format_processes,
     format_table,
+    format_zoom,
     is_actionable,
     latest_activity,
     parse_blacklist,
@@ -30,6 +34,8 @@ from core import (
     parse_marker_state,
     parse_ps,
     parse_todo_plan,
+    parse_todo_plan_all,
+    resolve_repo_name,
     rows_to_json,
     serialize_blacklist,
     serialize_clones_cache,
@@ -750,3 +756,153 @@ def test_format_table_next_task_truncated() -> None:
     table = format_table(rows, max_width=120)
     for line in table.splitlines():
         assert len(line) <= 120
+
+
+# --- parse_todo_plan_all (G9) ------------------------------------------------
+
+def test_parse_todo_plan_all_returns_every_unchecked_in_order() -> None:
+    """Given mixed checked/unchecked items, returns all unchecked in source order."""
+    text = (
+        "- [x] one (done)\n"
+        "- [ ] alpha\n"
+        "- [x] two (done)\n"
+        "- [ ] beta\n"
+        "- [ ] gamma\n"
+    )
+    assert parse_todo_plan_all(text) == ["alpha", "beta", "gamma"]
+
+
+def test_parse_todo_plan_all_skips_struck_through() -> None:
+    """Given struck-through unchecked items, they are excluded."""
+    text = "- [ ] ~~old~~ replaced\n- [ ] real one\n"
+    assert parse_todo_plan_all(text) == ["real one"]
+
+
+def test_parse_todo_plan_all_no_open_returns_empty() -> None:
+    """Given no open tasks, returns an empty list (not None)."""
+    assert parse_todo_plan_all("- [x] done\n- [x] also done\n") == []
+
+
+def test_parse_todo_plan_all_empty_string_returns_empty() -> None:
+    """Given empty input, returns an empty list."""
+    assert parse_todo_plan_all("") == []
+
+
+# --- resolve_repo_name (G9) --------------------------------------------------
+
+def test_resolve_repo_name_exact_owner_name_match() -> None:
+    """Given an exact 'owner/name' query, returns it when present."""
+    known = {"9atatimer/tds-utils", "9atatimer/foo", "other/bar"}
+    assert resolve_repo_name("9atatimer/tds-utils", known=known) == ["9atatimer/tds-utils"]
+
+
+def test_resolve_repo_name_basename_match_unique() -> None:
+    """Given a basename query matching exactly one repo, returns that repo."""
+    known = {"9atatimer/tds-utils", "9atatimer/foo", "other/bar"}
+    assert resolve_repo_name("tds-utils", known=known) == ["9atatimer/tds-utils"]
+
+
+def test_resolve_repo_name_basename_match_ambiguous() -> None:
+    """Given a basename owned by two orgs, returns both matches sorted."""
+    known = {"alpha/tds-utils", "beta/tds-utils", "alpha/foo"}
+    assert resolve_repo_name("tds-utils", known=known) == [
+        "alpha/tds-utils", "beta/tds-utils",
+    ]
+
+
+def test_resolve_repo_name_no_match_returns_empty() -> None:
+    """Given a query that matches nothing, returns an empty list."""
+    assert resolve_repo_name("nosuch", known={"a/x", "b/y"}) == []
+
+
+def test_resolve_repo_name_case_insensitive_basename() -> None:
+    """Given a query that differs only in case, still matches."""
+    known = {"9atatimer/TDS-Utils"}
+    assert resolve_repo_name("tds-utils", known=known) == ["9atatimer/TDS-Utils"]
+
+
+# --- format_zoom (G9) --------------------------------------------------------
+
+def _zoom(
+    *,
+    name: str = "9atatimer/tds-utils",
+    github: GithubInfo | None = None,
+    local: LocalInfo | None = None,
+    recent_commits: tuple[CommitSummary, ...] = (),
+    open_prs: tuple[PRSummary, ...] = (),
+    agents: tuple[AgentSession, ...] = (),
+    open_tasks: tuple[str, ...] = (),
+) -> ZoomData:
+    return ZoomData(
+        name=name,
+        github=github,
+        local=local,
+        recent_commits=recent_commits,
+        open_prs=open_prs,
+        agents=agents,
+        open_tasks=open_tasks,
+    )
+
+
+def test_format_zoom_includes_repo_name_header() -> None:
+    """Given any ZoomData, the first non-blank line names the repo."""
+    out = format_zoom(_zoom())
+    first = next(line for line in out.splitlines() if line.strip())
+    assert "9atatimer/tds-utils" in first
+
+
+def test_format_zoom_renders_recent_commits() -> None:
+    """Given recent commits, each appears with its short sha and subject."""
+    out = format_zoom(_zoom(recent_commits=(
+        CommitSummary(sha="84578fd", subject="chore(todo-plan): one"),
+        CommitSummary(sha="d1d549e", subject="chore(clai): two"),
+    )))
+    assert "84578fd" in out
+    assert "chore(todo-plan): one" in out
+    assert "d1d549e" in out
+
+
+def test_format_zoom_renders_open_prs_with_state() -> None:
+    """Given open PRs, each appears with number, title, author, and draft state."""
+    out = format_zoom(_zoom(open_prs=(
+        PRSummary(number=52, title="feat: thing", author="tstumpf", is_draft=True),
+        PRSummary(number=53, title="fix: bug", author="other", is_draft=False),
+    )))
+    assert "#52" in out
+    assert "feat: thing" in out
+    assert "draft" in out.lower()
+    assert "#53" in out
+
+
+def test_format_zoom_renders_all_open_tasks_not_just_first() -> None:
+    """Given multiple open tasks, every task is listed (not truncated to one)."""
+    tasks = tuple(f"task {i}" for i in range(5))
+    out = format_zoom(_zoom(open_tasks=tasks))
+    for t in tasks:
+        assert t in out
+
+
+def test_format_zoom_renders_local_branch_and_dirty_state() -> None:
+    """Given a LocalInfo with dirty=True, the output reflects that."""
+    out = format_zoom(_zoom(local=LocalInfo(
+        path=Path("/Users/x/workplace/tds-utils"),
+        is_dirty=True, ahead=2, behind=0,
+        branch="tstumpf/feat/foo",
+        last_commit_at=None, next_task=None,
+    )))
+    assert "tstumpf/feat/foo" in out
+    assert "/Users/x/workplace/tds-utils" in out
+    # dirty and ahead=2 should both be visible somewhere
+    assert "dirty" in out.lower()
+    assert "2" in out  # ahead count
+
+
+def test_format_zoom_shows_none_markers_for_missing_data() -> None:
+    """Given ZoomData with empty sections, those sections render a none/empty marker."""
+    out = format_zoom(_zoom())
+    # We don't assert a specific marker string -- just that no section blows up
+    # and the output is non-empty and includes recognisable section headers.
+    lower = out.lower()
+    assert "recent commits" in lower or "commits" in lower
+    assert "open prs" in lower or "prs" in lower
+    assert "tasks" in lower

--- a/goldfish/test_core.py
+++ b/goldfish/test_core.py
@@ -821,6 +821,14 @@ def test_resolve_repo_name_case_insensitive_basename() -> None:
     assert resolve_repo_name("tds-utils", known=known) == ["9atatimer/TDS-Utils"]
 
 
+def test_resolve_repo_name_case_insensitive_owner_name() -> None:
+    """Given an explicit owner/name with different casing, still matches."""
+    known = {"9atatimer/tds-utils"}
+    assert resolve_repo_name("9atatimer/TDS-Utils", known=known) == [
+        "9atatimer/tds-utils",
+    ]
+
+
 # --- format_zoom (G9) --------------------------------------------------------
 
 def _zoom(
@@ -892,9 +900,8 @@ def test_format_zoom_renders_local_branch_and_dirty_state() -> None:
     )))
     assert "tstumpf/feat/foo" in out
     assert "/Users/x/workplace/tds-utils" in out
-    # dirty and ahead=2 should both be visible somewhere
     assert "dirty" in out.lower()
-    assert "2" in out  # ahead count
+    assert "2 / 0" in out  # specific ahead/behind line, not any digit
 
 
 def test_format_zoom_shows_none_markers_for_missing_data() -> None:

--- a/lmde/LMDE.md
+++ b/lmde/LMDE.md
@@ -39,6 +39,16 @@ Any project running within this environment can assume the existence and availab
 
 ---
 
+## Residency: in-kind vs. on the host
+
+Not every Adopted component lives inside kind. The rule:
+
+- **Components reachable by kind-sandboxed coding agents must run inside (or be exposed into) the kind cluster.** Mac-local agents can hit either side; sandboxed agents only see what the cluster surfaces, so anything they consume needs an in-cluster path.
+- Components that only serve the host edge or *feed* kind itself (Caddy, dnsmasq, the local registry) can stay outside.
+- When a component's audience widens to include sandboxed agents, plan its move into the cluster.
+
+---
+
 ## Directory Structure
 
 - `lmde/LMDE.md`: This document (the contract).

--- a/test/smoketest_goldfish/07_repo_zoom.sh
+++ b/test/smoketest_goldfish/07_repo_zoom.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# 07_repo_zoom.sh — `goldfish <repo>` renders a one-repo summary with every open task.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    local todo
+    todo=$'# TODO_PLAN\n- [ ] task one\n- [x] done thing\n- [ ] task two\n- [ ] task three\n'
+    make_fake_clone "todd/zoom-target" "${todo}" >/dev/null
+    make_fake_clone "todd/other-repo" >/dev/null
+
+    # Basename resolution should pick zoom-target out of two clones.
+    out="$(run_goldfish zoom-target 2>/dev/null)"
+
+    if ! grep -q "todd/zoom-target" <<<"${out}"; then
+        echo "FAIL: repo name header missing:"
+        echo "${out}"
+        return 1
+    fi
+    for t in "task one" "task two" "task three"; do
+        if ! grep -qF "${t}" <<<"${out}"; then
+            echo "FAIL: open task '${t}' missing from zoom output:"
+            echo "${out}"
+            return 1
+        fi
+    done
+    if grep -qF "done thing" <<<"${out}"; then
+        echo "FAIL: completed task leaked into open-task list:"
+        echo "${out}"
+        return 1
+    fi
+    if ! grep -qi "recent commits" <<<"${out}"; then
+        echo "FAIL: 'Recent commits' section missing:"
+        echo "${out}"
+        return 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- **G9 (goldfish): repo-zoom mode.** `gf <repo>` renders a one-repo activity summary (GitHub state, local state, recent commits, open PRs with draft markers, agents in cwd, full open-task list from TODO_PLAN.md) instead of the cross-repo table. Basename resolution against the clones cache matches `gf tds-utils` → `9atatimer/tds-utils`; ambiguity returns a sorted candidate list; pass `owner/name` explicitly to zoom an uncloned repo.
- **LMDE residency rule.** Added to `lmde/LMDE.md`: components reachable by kind-sandboxed coding agents must run inside (or be exposed into) the kind cluster; host-edge / kind-feeding pieces (Caddy, dnsmasq, registry) stay outside.
- **LMDE12 / LMDE13.** Planned in `TODO_PLAN.md` — NATS-in-kind design doc and implementation, so kind-sandboxed agents reach the same bus as Mac-local agents.

## Test plan

- [x] `python3 -m pytest goldfish/test_core.py` — 97 passed (12 new for G9)
- [x] `bash test/smoketest_goldfish/run_all.sh` — `07_repo_zoom` PASS
- [x] Real-run: `gf tds-utils` renders the expected vertical block, all sections populated
- [ ] Pre-existing isolation flake: scenarios `01_local_clone_appears`, `05_clone_cache`, `06_org_filter` fail on master too. Root cause: `resolve_orgs()` falls through to `gh api user --jq .login` when `"orgs": []`, polluting the smoke env with real GH data. Out of scope for this PR; should be its own follow-up.