### PR TITLE
docs(github): start review-watch loop by default after PR creation

### DIFF
--- a/prompts/GITHUB.md
+++ b/prompts/GITHUB.md
@@ -94,10 +94,21 @@ Two transports, preferring push:
    arrive as `<github-webhook-activity>` blocks. Auto-removes on
    merge/close. Idempotent.
 2. **Polling (`ScheduleWakeup`) -- when MCP isn't loaded.** Dynamic
-   self-pacing. First wake ~10 min after PR open (past typical
-   AI-review latency); back off to 20-30 min on consecutive empties.
-   Pass the loop's continuation prompt verbatim to `ScheduleWakeup`
-   so the next wake re-enters this flow.
+   self-pacing with a **cache-aware tight cadence**. The Anthropic
+   prompt cache has a 5-min TTL; wakes ≤270s stay warm and cost
+   almost nothing per iteration, so don't pad delays for the sake
+   of feeling polite to the API.
+   - **First wake after PR open:** ~3 min (180s) -- Copilot needs a
+     beat to start; polling before that is wasted.
+   - **First wake after a push:** ~2 min (120s).
+   - **Empty polls while waiting:** every 2 min (120s).
+
+   Copilot's observed response window is ~4-6 min, so a 2-min cadence
+   catches it within ~2 min worst case, average ~3. Don't choose
+   delays in the 300-1200s range -- that's the worst-of-both (cache
+   miss without amortising the wait). Pass the loop's continuation
+   prompt verbatim to `ScheduleWakeup` so the next wake re-enters
+   this flow.
 
    **On wake, do these in order:**
    1. **Switch to the PR's head branch** (`git switch <branch>`).
@@ -122,8 +133,9 @@ Two transports, preferring push:
 mode also unsubscribe; in poll mode omit the next `ScheduleWakeup`):
 
 - PR merged or closed.
-- 3 consecutive empty polls (~1 hour quiescent at the documented
-  10-then-20-30min cadence).
+- 3 consecutive empty polls (~6 min quiescent at the documented
+  2-min cadence). Stop fast -- Copilot rarely returns late once
+  the response window has passed.
 - Architecturally ambiguous comment -> `AskUserQuestion` and stop.
   Don't guess at design calls.
 - **Quality drop**: when remaining unaddressed comments are nitpicks

--- a/prompts/GITHUB.md
+++ b/prompts/GITHUB.md
@@ -96,15 +96,34 @@ Two transports, preferring push:
 2. **Polling (`ScheduleWakeup`) -- when MCP isn't loaded.** Dynamic
    self-pacing. First wake ~10 min after PR open (past typical
    AI-review latency); back off to 20-30 min on consecutive empties.
-   Each wake runs `gadmin github pending-comments --repo <OWNER/REPO>
-   --pr <N>` and triages. Pass the loop's continuation prompt verbatim
-   to `ScheduleWakeup` so the next wake re-enters this flow.
+   Pass the loop's continuation prompt verbatim to `ScheduleWakeup`
+   so the next wake re-enters this flow.
+
+   **On wake, do these in order:**
+   1. **Switch to the PR's head branch** (`git switch <branch>`).
+      Otherwise `gadmin` may abort with a branch-mismatch warning and
+      hide real pending comments. The user can be on any branch
+      between turns; the loop is responsible for landing on the
+      right one before any `gadmin` call.
+   2. Check top-level reviews with `gh pr view <NUMBER> --json reviews`
+      to catch **overview-only reviews** (`state=COMMENTED` body with
+      no inline comments). `gadmin pending-comments` only surfaces
+      inline comments, so overview-only reviews are invisible to it.
+      - Overview **with** inline comments -> proceed to step 3.
+      - Overview **only** (no inline) -> ack briefly and continue;
+        don't reply per overview event.
+      - No new review since last poll -> empty poll, increment the
+        empty-poll counter, schedule the next wake.
+   3. Fetch unaddressed inline comments with
+      `gadmin github pending-comments --repo <OWNER/REPO> --pr <NUMBER>`
+      and triage per the auto-action threshold below.
 
 **Termination conditions** (any one fires -> stop the loop; in MCP
 mode also unsubscribe; in poll mode omit the next `ScheduleWakeup`):
 
 - PR merged or closed.
-- 12 consecutive empty polls (~1 hour quiescent).
+- 3 consecutive empty polls (~1 hour quiescent at the documented
+  10-then-20-30min cadence).
 - Architecturally ambiguous comment -> `AskUserQuestion` and stop.
   Don't guess at design calls.
 - **Quality drop**: when remaining unaddressed comments are nitpicks

--- a/prompts/GITHUB.md
+++ b/prompts/GITHUB.md
@@ -174,6 +174,21 @@ mode also unsubscribe; in poll mode omit the next `ScheduleWakeup`):
 - If **no action is needed** (echo, informational, noise), skip and
   say so briefly.
 
+**After each productive push, re-request Copilot review** with
+`gh pr edit <NUMBER> --add-reviewer @copilot`. GitHub's CLI special-cases
+`@copilot` (shipped 2026-03) to trigger the Copilot review bot; the
+regular `requested_reviewers` REST API rejects it as "not a collaborator."
+Without this step Copilot does **not** auto-re-review on `synchronize`
+events and the loop polls fallow.
+
+- Skip when no fix was pushed this round -- the next review would just
+  repeat the prior one.
+- `gh pr view --json reviewRequests` will often show empty after firing;
+  Copilot consumes the request near-instantly.
+- Works with user PATs (the standard `gh auth` flow); reportedly fails
+  with GitHub Actions bot tokens and some org custom apps. For an
+  agentic loop running under the user's own gh auth, it works.
+
 ## Automated Review Response
 
 This is the procedure for handling a batch of review feedback -- whether it

--- a/prompts/GITHUB.md
+++ b/prompts/GITHUB.md
@@ -95,7 +95,7 @@ Two transports, preferring push:
    merge/close. Idempotent.
 2. **Polling (`ScheduleWakeup`) -- when MCP isn't loaded.** Dynamic
    self-pacing. Per the global 240s-max rule in `~/.claude/CLAUDE.md`,
-   all wakes here are ≤4 min (the global rule wins; no longer wakes
+   all wakes here are <= 4 min (the global rule wins; no longer wakes
    without human approval).
    - **First wake after PR open:** ~3 min (180s) -- Copilot needs a
      beat to start; polling before that is wasted.
@@ -124,8 +124,9 @@ Two transports, preferring push:
         only surfaces inline comments, so overview-only reviews are
         invisible to it.
         - Overview **with** inline comments -> proceed to step 3.
-        - Overview **only** (no inline) -> ack briefly and continue;
-          don't reply per overview event.
+        - Overview **only** (no inline) -> log internally and
+          continue the loop; do not post a GitHub reply (overviews
+          don't require one).
         - No new review since last poll -> empty poll, increment the
           empty-poll counter, schedule the next wake.
    3. Fetch unaddressed inline comments with
@@ -133,7 +134,11 @@ Two transports, preferring push:
       and triage per the auto-action threshold below.
 
 **Termination conditions** (any one fires -> stop the loop; in MCP
-mode also unsubscribe; in poll mode omit the next `ScheduleWakeup`):
+mode ignore any subsequent `<github-webhook-activity>` events even
+if the subscription remains live -- the MCP server auto-removes the
+subscription on merge/close, but for the other exit conditions
+there's no documented explicit unsubscribe; in poll mode omit the
+next `ScheduleWakeup`):
 
 - PR merged or closed.
 - 3 consecutive empty polls (~6 min quiescent at the documented

--- a/prompts/GITHUB.md
+++ b/prompts/GITHUB.md
@@ -123,11 +123,14 @@ Two transports, preferring push:
         no inline comments). `gadmin github pending-comments` only
         surfaces inline comments, so overview-only reviews are
         invisible to it and have to be tracked from this step.
-   3. **Always run `gadmin github pending-comments --repo <OWNER/REPO>
-      --pr <NUMBER>`** to fetch unaddressed inline comments. Do not
-      short-circuit this step based on step 2 -- standalone inline
+   3. **Always fetch unaddressed inline comments** -- do not
+      short-circuit based on step 2, because standalone inline
       comments (e.g., human replies that aren't part of any
-      `pullrequestreview`) only show up here.
+      `pullrequestreview`) only show up here:
+
+      ```
+      gadmin github pending-comments --repo <OWNER/REPO> --pr <NUMBER>
+      ```
    4. **Triage and decide what kind of poll this was:**
       - Pending inline non-empty -> apply the auto-action threshold
         below; after a productive push, run

--- a/prompts/GITHUB.md
+++ b/prompts/GITHUB.md
@@ -103,9 +103,9 @@ Two transports, preferring push:
    - **Empty polls while waiting:** every 2 min (120s).
 
    Copilot's observed response window is ~4-6 min, so a 2-min cadence
-   catches it within ~2 min worst case, average ~3. Pass the loop's
-   continuation prompt verbatim to `ScheduleWakeup` so the next wake
-   re-enters this flow.
+   catches a posted review within 2 min worst case and ~1 min on
+   average. Pass the loop's continuation prompt verbatim to
+   `ScheduleWakeup` so the next wake re-enters this flow.
 
    **On wake, do these in order:**
    1. **Switch to the PR's head branch** (`git switch <BRANCH>`).

--- a/prompts/GITHUB.md
+++ b/prompts/GITHUB.md
@@ -79,22 +79,43 @@ output. ANSI codes are stripped automatically.
 the subscription stream, **do not re-fetch it.** The webhook payload is the
 source of truth for that thread -- reply directly from the comment ID.
 
-## PR Activity Subscription (push model)
+## Review-watch loop (default after opening a PR)
 
-You can subscribe a session to a PR's webhook stream via the
-`mcp__github__subscribe_pr_activity` tool. Once subscribed:
+When you open a PR with `gh pr create`, **start the review-watch loop
+by default** -- don't wait for the human to ask. This implements the
+"Iterative Review" cycle above: address Copilot feedback, push, wait
+for re-review, repeat until quiescent. Applies to both human-driven
+(`tstumpf/*`) and agent-driven (`claude/*`) PRs.
 
-- New comments, reviews, CI status changes, merge, and close events arrive
-  in the conversation as `<github-webhook-activity>` blocks.
-- The subscription is auto-removed when the PR merges or closes.
-- Subscription is idempotent -- calling it twice is harmless.
+Two transports, preferring push:
 
-**When to subscribe:**
+1. **Subscription (push) -- if the GitHub MCP server is loaded.** Call
+   `mcp__github__subscribe_pr_activity` with the PR number. Events
+   arrive as `<github-webhook-activity>` blocks. Auto-removes on
+   merge/close. Idempotent.
+2. **Polling (`ScheduleWakeup`) -- when MCP isn't loaded.** Dynamic
+   self-pacing. First wake ~10 min after PR open (past typical
+   AI-review latency); back off to 20-30 min on consecutive empties.
+   Each wake runs `gadmin github pending-comments --repo <OWNER/REPO>
+   --pr <N>` and triages. Pass the loop's continuation prompt verbatim
+   to `ScheduleWakeup` so the next wake re-enters this flow.
 
-- Immediately after opening a PR, if the human asks you to watch / babysit
-  / autofix / monitor / respond to it.
-- Skip if the human hasn't asked for active engagement (a one-shot PR
-  doesn't need a subscription).
+**Termination conditions** (any one fires -> stop the loop; in MCP
+mode also unsubscribe; in poll mode omit the next `ScheduleWakeup`):
+
+- PR merged or closed.
+- 12 consecutive empty polls (~1 hour quiescent).
+- Architecturally ambiguous comment -> `AskUserQuestion` and stop.
+  Don't guess at design calls.
+- **Quality drop**: when remaining unaddressed comments are nitpicks
+  (style trivia, "consider renaming X to Y" with no concrete reason,
+  alternative phrasings of working code), push back -- reject with a
+  one-line reason per the threshold below. If Copilot re-asserts the
+  same nit on the next pass, post one summary reply ("remaining
+  suggestions are stylistic; not addressing in this PR") and stop.
+  Don't loop on bikeshedding.
+- Human says "stop the loop" / "stop watching" / similar -> stop.
+  Don't argue.
 
 **Event taxonomy and triage policy:**
 
@@ -103,17 +124,21 @@ You can subscribe a session to a PR's webhook stream via the
 | Review overview (`pullrequestreview`, often with N inline comments queued behind it) | Fetch the full review_comments list **once** via `gadmin` and triage the whole batch. Do not reply per inline event. |
 | Single inline `pull_request_review_comment` (no review overview, e.g. a human reply) | Triage and act on that one thread. |
 | `check_run` failure | Get the failing job's log via `gadmin github actions get-job`; classify (flake / config / real bug); fix or report. |
-| `merged` / `closed` | Acknowledge and stop watching; you're auto-unsubscribed. |
+| `merged` / `closed` | Acknowledge and stop watching; you're auto-unsubscribed (MCP) or omit next wakeup (poll). |
 | **Echo of your own reply** (author is you, body matches what you just posted) | **Skip.** Every reply you post comes back as a webhook event ~1s later. Recognise and discard. |
 
 **Auto-action threshold (apply on every event):**
 
-- If the change is **small and unambiguous**, make it, push, reply with the
-  SHA. No need to ask first.
-- If the change is **ambiguous or architecturally significant**, ask the
-  human before acting. Use `AskUserQuestion` so the question is in-band.
-- If **no action is needed** (echo, informational, noise), skip and say so
-  briefly.
+- If the change is **small and unambiguous**, make it, push, reply with
+  the SHA. No need to ask first.
+- If the change is **ambiguous or architecturally significant**, ask
+  the human before acting. Use `AskUserQuestion` so the question is
+  in-band.
+- If you **disagree** with a comment, reject it with a one-line
+  concrete reason. Never just "disagree." Don't be a yes-man to
+  Copilot -- reviewer pushback is the point of the loop.
+- If **no action is needed** (echo, informational, noise), skip and
+  say so briefly.
 
 ## Automated Review Response
 

--- a/prompts/GITHUB.md
+++ b/prompts/GITHUB.md
@@ -108,20 +108,26 @@ Two transports, preferring push:
    re-enters this flow.
 
    **On wake, do these in order:**
-   1. **Switch to the PR's head branch** (`git switch <branch>`).
+   1. **Switch to the PR's head branch** (`git switch <BRANCH>`).
       Otherwise `gadmin` may abort with a branch-mismatch warning and
       hide real pending comments. The user can be on any branch
       between turns; the loop is responsible for landing on the
       right one before any `gadmin` call.
-   2. Check top-level reviews with `gh pr view <NUMBER> --json reviews`
-      to catch **overview-only reviews** (`state=COMMENTED` body with
-      no inline comments). `gadmin pending-comments` only surfaces
-      inline comments, so overview-only reviews are invisible to it.
-      - Overview **with** inline comments -> proceed to step 3.
-      - Overview **only** (no inline) -> ack briefly and continue;
-        don't reply per overview event.
-      - No new review since last poll -> empty poll, increment the
-        empty-poll counter, schedule the next wake.
+   2. **Check the PR state and any new reviews** with
+      `gh pr view <NUMBER> --json state,mergedAt,reviews` in one
+      call.
+      - `state` is `MERGED` or `CLOSED` -> terminate the loop
+        immediately, skip the rest of the steps below.
+      - Otherwise inspect `reviews` for new entries since the last
+        poll to catch **overview-only reviews** (`state=COMMENTED`
+        body with no inline comments). `gadmin github pending-comments`
+        only surfaces inline comments, so overview-only reviews are
+        invisible to it.
+        - Overview **with** inline comments -> proceed to step 3.
+        - Overview **only** (no inline) -> ack briefly and continue;
+          don't reply per overview event.
+        - No new review since last poll -> empty poll, increment the
+          empty-poll counter, schedule the next wake.
    3. Fetch unaddressed inline comments with
       `gadmin github pending-comments --repo <OWNER/REPO> --pr <NUMBER>`
       and triage per the auto-action threshold below.

--- a/prompts/GITHUB.md
+++ b/prompts/GITHUB.md
@@ -94,21 +94,18 @@ Two transports, preferring push:
    arrive as `<github-webhook-activity>` blocks. Auto-removes on
    merge/close. Idempotent.
 2. **Polling (`ScheduleWakeup`) -- when MCP isn't loaded.** Dynamic
-   self-pacing with a **cache-aware tight cadence**. The Anthropic
-   prompt cache has a 5-min TTL; wakes ≤270s stay warm and cost
-   almost nothing per iteration, so don't pad delays for the sake
-   of feeling polite to the API.
+   self-pacing. Per the global 240s-max rule in `~/.claude/CLAUDE.md`,
+   all wakes here are ≤4 min (the global rule wins; no longer wakes
+   without human approval).
    - **First wake after PR open:** ~3 min (180s) -- Copilot needs a
      beat to start; polling before that is wasted.
    - **First wake after a push:** ~2 min (120s).
    - **Empty polls while waiting:** every 2 min (120s).
 
    Copilot's observed response window is ~4-6 min, so a 2-min cadence
-   catches it within ~2 min worst case, average ~3. Don't choose
-   delays in the 300-1200s range -- that's the worst-of-both (cache
-   miss without amortising the wait). Pass the loop's continuation
-   prompt verbatim to `ScheduleWakeup` so the next wake re-enters
-   this flow.
+   catches it within ~2 min worst case, average ~3. Pass the loop's
+   continuation prompt verbatim to `ScheduleWakeup` so the next wake
+   re-enters this flow.
 
    **On wake, do these in order:**
    1. **Switch to the PR's head branch** (`git switch <branch>`).

--- a/prompts/GITHUB.md
+++ b/prompts/GITHUB.md
@@ -113,25 +113,31 @@ Two transports, preferring push:
       hide real pending comments. The user can be on any branch
       between turns; the loop is responsible for landing on the
       right one before any `gadmin` call.
-   2. **Check the PR state and any new reviews** with
+   2. **Check PR state and reviews** with
       `gh pr view <NUMBER> --json state,mergedAt,reviews` in one
       call.
-      - `state` is `MERGED` or `CLOSED` -> terminate the loop
-        immediately, skip the rest of the steps below.
-      - Otherwise inspect `reviews` for new entries since the last
-        poll to catch **overview-only reviews** (`state=COMMENTED`
-        body with no inline comments). `gadmin github pending-comments`
-        only surfaces inline comments, so overview-only reviews are
-        invisible to it.
-        - Overview **with** inline comments -> proceed to step 3.
-        - Overview **only** (no inline) -> log internally and
-          continue the loop; do not post a GitHub reply (overviews
-          don't require one).
-        - No new review since last poll -> empty poll, increment the
-          empty-poll counter, schedule the next wake.
-   3. Fetch unaddressed inline comments with
-      `gadmin github pending-comments --repo <OWNER/REPO> --pr <NUMBER>`
-      and triage per the auto-action threshold below.
+      - If `state` is `MERGED` or `CLOSED` -> terminate the loop
+        immediately; skip everything below.
+      - Otherwise, note any new reviews since the last poll --
+        especially overview-only ones (`state=COMMENTED` body with
+        no inline comments). `gadmin github pending-comments` only
+        surfaces inline comments, so overview-only reviews are
+        invisible to it and have to be tracked from this step.
+   3. **Always run `gadmin github pending-comments --repo <OWNER/REPO>
+      --pr <NUMBER>`** to fetch unaddressed inline comments. Do not
+      short-circuit this step based on step 2 -- standalone inline
+      comments (e.g., human replies that aren't part of any
+      `pullrequestreview`) only show up here.
+   4. **Triage and decide what kind of poll this was:**
+      - Pending inline non-empty -> apply the auto-action threshold
+        below; after a productive push, run
+        `gh pr edit <NUMBER> --add-reviewer @copilot` to trigger
+        the next round; reset the empty-poll counter.
+      - Pending inline empty + new overview-only review in step 2
+        -> log the overview, reset the empty-poll counter (something
+        happened, just nothing to act on), schedule next wake.
+      - Pending inline empty + no new review since last poll ->
+        empty poll, increment the counter, schedule next wake.
 
 **Termination conditions** (any one fires -> stop the loop; in MCP
 mode ignore any subsequent `<github-webhook-activity>` events even


### PR DESCRIPTION
## Summary

- Flips the GITHUB.md trigger from "subscribe if the human asks" to "start by default after \`gh pr create\`". Applies to both \`tstumpf/*\` and \`claude/*\` PRs.
- Documents the polling fallback via \`ScheduleWakeup\` when the GitHub MCP server isn't loaded. Cadence is bounded by the global 240s-max rule in \`~/.claude/CLAUDE.md\` (no wakes longer than 4 min without human approval); 2-min empty polls catch Copilot's ~4–6 min response window within ~2 min worst case.
- Adds three termination conditions on top of merged/closed: 3 consecutive empty polls (~6 min quiescent at the 2-min cadence), an explicit \`AskUserQuestion\` exit on architecturally ambiguous comments, and a quality-drop exit (push back on nitpicks once; if Copilot re-asserts, post a one-line "stylistic, stopping here" summary and exit).
- Adds the on-wake procedure: \`git switch <BRANCH>\`, then \`gh pr view --json state,mergedAt,reviews\` (terminates early on MERGED/CLOSED, catches overview-only reviews), then \`gadmin github pending-comments\` for inline pending.
- Strengthens the disagree path: never just "disagree", always a concrete one-line reason; reviewer pushback is the point of the loop.

Motivation: today, getting Claude into a Copilot review loop requires the human to manually fire \`/loop\`. With this change a fresh session does it automatically once the PR is open, and self-terminates cleanly (merged / quiescent / nitpicky / explicit stop). No more user intervention needed for the normal happy path. Related: issue #55 captures the follow-up to bundle the on-wake dance into a single \`gadmin github review-state\` verb.

## Test plan

- [ ] On the next PR opened from a Claude session, observe whether the agent starts the watch loop without being asked
- [ ] Verify the quality-drop exit fires when Copilot's remaining comments are stylistic (vs. just looping indefinitely)
- [ ] Verify "stop the loop" in chat actually terminates (human-interrupt path)
- [ ] Verify the on-wake branch-switch + PR-state-check sequence catches merged/closed and overview-only reviews