### PR TITLE
fix(observability): add no-op trace and log pipelines to OTel collector

### DIFF
--- a/lmde/components/observability/specs/otel-collector/config.yaml
+++ b/lmde/components/observability/specs/otel-collector/config.yaml
@@ -27,6 +27,8 @@ data:
         endpoint: "0.0.0.0:8889"
         resource_to_telemetry_conversion:
           enabled: true
+      file/blackhole:
+        path: /dev/null
 
     service:
       pipelines:
@@ -34,3 +36,9 @@ data:
           receivers: [otlp]
           processors: [batch]
           exporters: [prometheus]
+        traces:
+          receivers: [otlp]
+          exporters: [file/blackhole]
+        logs:
+          receivers: [otlp]
+          exporters: [file/blackhole]


### PR DESCRIPTION
## Summary

- Agents (e.g. Gemini CLI) unconditionally flush `OTLPTraceExporter` and `OTLPLogExporter` on shutdown
- Without trace/log pipelines the collector returned 404, causing noisy error output on every agent exit
- Routes both signals to `file/blackhole` (`/dev/null`) so the collector returns 200 and the SDK shuts down silently
- Metrics pipeline unchanged

## Test plan

- [ ] `kubectl rollout status deployment/otel-collector -n observability` — healthy
- [ ] `curl -X POST http://localhost:4318/v1/traces` returns 200
- [ ] `curl -X POST http://localhost:4318/v1/logs` returns 200
- [ ] `clai gemini` exits with no `OTLPExporterError` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)