### PR TITLE
Add remvllm: remote vLLM orchestrator for multi-GPU inference

### DIFF
--- a/bin/remvllm
+++ b/bin/remvllm
@@ -8,8 +8,8 @@
 #
 # Usage:
 #   remvllm run <recipe> [--gpu a100|h100|h200|b200|auto] [--quant int4|fp8]
-#                        [--ttl <min>] [--no-spot] [-v]
-#   remvllm sizes [--quant int4|fp8] [--on-demand]   # cost matrix + auto pick
+#                        [--max-gpus N] [--ttl <min>] [--no-spot] [-v]
+#   remvllm sizes [--quant int4|fp8] [--max-gpus N] [--on-demand]  # cost matrix
 #   remvllm status
 #   remvllm stop                                     # close tunnel, keep node
 #   remvllm destroy                                  # terraform destroy now
@@ -77,6 +77,7 @@ cmd_sizes() {
     while [[ $# -gt 0 ]]; do
         case "$1" in
             --quant) quant="$2"; shift 2 ;;
+            --max-gpus) REMVLLM_MAX_GPUS="$2"; shift 2 ;;
             --on-demand) pricing="ondemand"; shift ;;
             *) shift ;;
         esac
@@ -89,9 +90,10 @@ cmd_run() {
     local gpu="${REMVLLM_GPU_TYPE}" quant="${REMVLLM_QUANT}"
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --gpu)     gpu="$2"; shift 2 ;;
-            --quant)   quant="$2"; shift 2 ;;
-            --ttl)     REMVLLM_TTL_MINUTES="$2"; shift 2 ;;
+            --gpu)      gpu="$2"; shift 2 ;;
+            --quant)    quant="$2"; shift 2 ;;
+            --max-gpus) REMVLLM_MAX_GPUS="$2"; shift 2 ;;
+            --ttl)      REMVLLM_TTL_MINUTES="$2"; shift 2 ;;
             --no-spot) REMVLLM_SPOT=false; shift ;;
             -v|--verbose) set -x; shift ;;
             *) echo "error: unknown flag '$1'" >&2; return 1 ;;

--- a/bin/remvllm
+++ b/bin/remvllm
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# remvllm — Remote vLLM orchestrator (sister to remollama).
+#
+# Provisions a multi-GPU SPOT node, serves a large open-weight model (GLM-5.2 by
+# default) with vLLM, and exposes an OpenAI-compatible API at localhost via SSH
+# tunnel. Cheapest-first by design; weights are cached in a bucket so Hugging
+# Face is downloaded exactly once.
+#
+# Usage:
+#   remvllm run <recipe> [--gpu a100|h100|h200|b200|auto] [--quant int4|fp8]
+#                        [--ttl <min>] [--no-spot] [-v]
+#   remvllm sizes [--quant int4|fp8] [--on-demand]   # cost matrix + auto pick
+#   remvllm status
+#   remvllm stop                                     # close tunnel, keep node
+#   remvllm destroy                                  # terraform destroy now
+#   remvllm cache <recipe>                           # warm the bucket from HF
+#   remvllm list-recipes
+#
+# Prerequisites: bash 5.2+, terraform, ssh, op (1Password), jq, curl, awk.
+set -euo pipefail
+
+# --- Shared libraries --------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+REMVLLM_OPS_DIR="${REMVLLM_OPS_DIR:-${REPO_DIR}/ops/terraform/remvllm}"
+export REMVLLM_OPS_DIR
+
+# shellcheck source=../ops/terraform/remvllm/lib/config.sh
+source "${REMVLLM_OPS_DIR}/lib/config.sh"
+# shellcheck source=../ops/terraform/remvllm/lib/sizing.sh
+source "${REMVLLM_OPS_DIR}/lib/sizing.sh"
+# shellcheck source=../ops/terraform/remvllm/lib/state.sh
+source "${REMVLLM_OPS_DIR}/lib/state.sh"
+# shellcheck source=../ops/terraform/remvllm/lib/modelcache.sh
+source "${REMVLLM_OPS_DIR}/lib/modelcache.sh"
+# shellcheck source=../ops/terraform/remvllm/lib/secrets.sh
+source "${REMVLLM_OPS_DIR}/lib/secrets.sh"
+# shellcheck source=../ops/terraform/remvllm/lib/tunnel.sh
+source "${REMVLLM_OPS_DIR}/lib/tunnel.sh"
+# shellcheck source=../ops/terraform/remvllm/lib/watchdog.sh
+source "${REMVLLM_OPS_DIR}/lib/watchdog.sh"
+# shellcheck source=../ops/terraform/remvllm/lib/orchestrate.sh
+source "${REMVLLM_OPS_DIR}/lib/orchestrate.sh"
+
+# --- Helper functions --------------------------------------------------------
+
+usage() { sed -n '2,30p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; }
+
+recipe_dir()  { printf '%s/recipes/%s\n' "${REMVLLM_OPS_DIR}" "$1"; }
+recipe_conf() { printf '%s/recipe.conf\n' "$(recipe_dir "$1")"; }
+
+require_recipe() {
+    local recipe="$1"
+    if [[ ! -f "$(recipe_conf "${recipe}")" ]]; then
+        echo "error: unknown recipe '${recipe}'. Try: remvllm list-recipes" >&2
+        return 1
+    fi
+}
+
+# Materialize the SSH private key to a locked-down temp file for the session and
+# schedule its removal. ssh -i needs a file; we minimize exposure (0600, EXIT trap).
+provision_key_file() {
+    local dir keyfile
+    dir="$(mktemp -d)"
+    keyfile="${dir}/id"
+    ( umask 077; secrets_provider_ssh_key > "${keyfile}" )
+    # shellcheck disable=SC2064
+    trap "rm -rf '${dir}'" EXIT
+    printf '%s\n' "${keyfile}"
+}
+
+# --- Flow functions ----------------------------------------------------------
+
+cmd_sizes() {
+    local quant="${REMVLLM_QUANT}" pricing="spot"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --quant) quant="$2"; shift 2 ;;
+            --on-demand) pricing="ondemand"; shift ;;
+            *) shift ;;
+        esac
+    done
+    sizing_matrix "${quant}" "${pricing}"
+}
+
+cmd_run() {
+    local recipe="${1:-glm-5.2}"; shift || true
+    local gpu="${REMVLLM_GPU_TYPE}" quant="${REMVLLM_QUANT}"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --gpu)     gpu="$2"; shift 2 ;;
+            --quant)   quant="$2"; shift 2 ;;
+            --ttl)     REMVLLM_TTL_MINUTES="$2"; shift 2 ;;
+            --no-spot) REMVLLM_SPOT=false; shift ;;
+            -v|--verbose) set -x; shift ;;
+            *) echo "error: unknown flag '$1'" >&2; return 1 ;;
+        esac
+    done
+    require_recipe "${recipe}"
+    REMVLLM_QUANT="${quant}"
+
+    local plan
+    if ! plan="$(sizing_plan "${quant}" "${gpu}" \
+            "$([[ "${REMVLLM_SPOT}" == "true" ]] && echo spot || echo ondemand)")"; then
+        return 1
+    fi
+    export REMVLLM_PLAN="${plan}"
+    export REMVLLM_KEY_FILE; REMVLLM_KEY_FILE="$(provision_key_file)"
+
+    orchestrate_run "${recipe}"
+}
+
+cmd_status() {
+    local base="${REMVLLM_STATE_DIR:-${REMVLLM_OPS_DIR}/state}"
+    if ! state_has_instance "${base}"; then
+        echo "no remvllm node provisioned on this host."
+        return 0
+    fi
+    local file
+    file="$(state_file "${base}")"
+    jq -r '
+      "recipe:    \(.recipe)",
+      "node:      \(.gpu_count)x \(.gpu_type) (\(.quant), spot=\(.spot))",
+      "endpoint:  http://localhost:'"${REMVLLM_LOCAL_PORT}"'/v1",
+      "host:      \(.host):\(.ssh_port)",
+      "est cost:  $\(.est_cost_hr)/hr",
+      "ttl:       \(.ttl_expires_at)",
+      "status:    \(.status)"' "${file}"
+}
+
+cmd_cache() {
+    local recipe="${1:-glm-5.2}"
+    require_recipe "${recipe}"
+    # shellcheck disable=SC1090
+    source "$(recipe_conf "${recipe}")"
+    local uri
+    uri="$(modelcache_uri "${REMVLLM_BUCKET_URL}" "${RECIPE_MODEL_ID}" "${REMVLLM_QUANT}")"
+    echo "cache target for ${RECIPE_MODEL_ID} (${REMVLLM_QUANT}): ${uri}"
+    echo "warming the cache spins up a node to download from HF once; run:"
+    echo "  remvllm run ${recipe}    (first run populates the bucket automatically)"
+}
+
+cmd_list_recipes() {
+    local d
+    for d in "${REMVLLM_OPS_DIR}"/recipes/*/; do
+        [[ -f "${d}/recipe.conf" ]] && basename "${d}"
+    done
+}
+
+# --- Main --------------------------------------------------------------------
+
+main() {
+    if [[ $# -eq 0 || "$1" == "-h" || "$1" == "--help" ]]; then
+        usage; exit 0
+    fi
+    config_load "${REMVLLM_OPS_DIR}"
+
+    local cmd="$1"; shift
+    case "${cmd}" in
+        run)          cmd_run "$@" ;;
+        sizes)        cmd_sizes "$@" ;;
+        status)       cmd_status ;;
+        stop)         orchestrate_stop ;;
+        destroy)      orchestrate_destroy ;;
+        cache)        cmd_cache "$@" ;;
+        list-recipes) cmd_list_recipes ;;
+        *) echo "error: unknown command '${cmd}'" >&2; usage; exit 1 ;;
+    esac
+}
+
+main "$@"

--- a/docs/design/REMVLLM.DESIGN.md
+++ b/docs/design/REMVLLM.DESIGN.md
@@ -1,4 +1,4 @@
-# remvllm — Remote vLLM Orchestrator (GLM-5.2 endpoint)
+# remvllm -- Remote vLLM Orchestrator (GLM-5.2 endpoint)
 
 > **Status:** Design / Pre-Implementation
 > **Created:** 2026-06-17
@@ -13,7 +13,7 @@
 `remvllm` is the sister tool to `remollama`. Where `remollama` runs Ollama on a
 single GPU, `remvllm` provisions a **multi-GPU spot node**, serves a large
 open-weight model with **vLLM**, and exposes an **OpenAI-compatible API** on
-`localhost` via SSH tunnel. The first-class target is **GLM-5.2** — a 744B-param
+`localhost` via SSH tunnel. The first-class target is **GLM-5.2** -- a 744B-param
 MoE (~40B active, 1M context, MIT license, weights at `zai-org/GLM-5.2`) that is
 far too large for Ollama-on-one-GPU.
 
@@ -22,35 +22,35 @@ Two hard constraints drive the design:
 1. **Cheapest possible per hour.** Spot/preemptible instances by default, lowest
    viable quant by default, cheapest GPU that fits. Preemption is acceptable.
 2. **Download the weights from Hugging Face exactly once.** Weights are cached in
-   an object bucket (Cloudflare **R2** by default — zero egress). Every node pulls
+   an object bucket (Cloudflare **R2** by default -- zero egress). Every node pulls
    from the bucket; HF is only ever hit to *populate* the cache.
 
 ---
 
 ## Goals
 
-1. **One-command endpoint** — `remvllm run glm-5.2` yields an OpenAI-compatible
+1. **One-command endpoint** -- `remvllm run glm-5.2` yields an OpenAI-compatible
    API at `localhost:<port>` speaking `/v1/chat/completions`.
-2. **Cheapest by default** — the sizer picks the lowest-cost spot config that fits
+2. **Cheapest by default** -- the sizer picks the lowest-cost spot config that fits
    the chosen quant; `remvllm sizes` shows the cost matrix.
-3. **HF downloaded once** — after the first cold start, all weights come from the
+3. **HF downloaded once** -- after the first cold start, all weights come from the
    bucket. Verifiable: a second cold start makes zero HF requests.
-4. **Selectable GPU and quant** — `--gpu` and `--quant` override the auto pick;
+4. **Selectable GPU and quant** -- `--gpu` and `--quant` override the auto pick;
    invalid combos (won't fit in VRAM) are refused with an actionable message.
-5. **Preemption-tolerant** — a reclaimed spot node is detected on the next `run`
+5. **Preemption-tolerant** -- a reclaimed spot node is detected on the next `run`
    and re-provisioned cheaply (weights already in the bucket).
-6. **Belt-and-suspenders spend control** — client TTL watchdog + server idle
+6. **Belt-and-suspenders spend control** -- client TTL watchdog + server idle
    watchdog, inherited from the remollama model.
 
 ---
 
 ## Non-Goals
 
-- **Replacing remollama** — remollama stays the right tool for small models on one
+- **Replacing remollama** -- remollama stays the right tool for small models on one
   GPU. remvllm is for big MoE models that need tensor + expert parallelism.
-- **Training / fine-tuning** — inference serving only.
-- **Multi-user / shared serving** — single operator, SSH-tunnel access only.
-- **Guaranteeing availability** — spot nodes get reclaimed; that is the accepted
+- **Training / fine-tuning** -- inference serving only.
+- **Multi-user / shared serving** -- single operator, SSH-tunnel access only.
+- **Guaranteeing availability** -- spot nodes get reclaimed; that is the accepted
   trade for price. We optimize fast recovery, not zero downtime.
 
 ---
@@ -66,12 +66,12 @@ Two hard constraints drive the design:
 |  Lifecycle, state, TTL, sizing, model-cache sync, SSH tunnels      |
 +------------------------------------------------------------------+
 |  Provisioning Layer                            modules/<provider> |
-|  Terraform — one module per cloud provider                        |
+|  Terraform -- one module per cloud provider                        |
 |  Contract: "get me N GPUs of type T on a SPOT node, with podman"  |
 +------------------------------------------------------------------+
 |  Runtime Layer                                 container/         |
 |  The remvllm appliance container                                  |
-|  fetch-model + vLLM + sshd + watchdog — identical everywhere      |
+|  fetch-model + vLLM + sshd + watchdog -- identical everywhere      |
 +------------------------------------------------------------------+
                               |
                               v
@@ -89,13 +89,13 @@ the **sizer** (multi-GPU, cost-driven), and the **model cache** (bucket-backed).
 
 ## Design
 
-### Sizing Layer (`lib/sizing.sh`) — the penny-pincher
+### Sizing Layer (`lib/sizing.sh`) -- the penny-pincher
 
 The sizer answers: *given a quant and (optionally) a GPU type, what is the
 cheapest spot configuration that fits, and will it fit at all?*
 
 It is data-driven from tunable tables (prices are spot $/hr estimates, Spheron,
-2026-06 — easy to edit as the market moves):
+2026-06 -- easy to edit as the market moves):
 
 | GPU | VRAM/GPU | Spot $/hr | On-demand $/hr |
 |-----|----------|-----------|----------------|
@@ -111,7 +111,7 @@ It is data-driven from tunable tables (prices are spot $/hr estimates, Spheron,
 
 **Target platform: a 4-GPU single node.** `REMVLLM_MAX_GPUS` (default **4**) caps
 the configuration. Four GPUs on one node sit on NVLink (no cross-node fabric),
-serve MoE inference better than 8, and — critically — are routinely schedulable
+serve MoE inference better than 8, and -- critically -- are routinely schedulable
 on spot, where 8-GPU boxes are scarce and preemption-prone. Designing to 4 keeps
 us out of that corner. `--max-gpus 8` overrides for the rare fp8 run.
 
@@ -120,7 +120,7 @@ Algorithm:
 1. `count = smallest valid tensor-parallel size in {1,2,4,8} such that
    count * vram_per_gpu >= required_vram AND count <= REMVLLM_MAX_GPUS`. (TP is
    constrained to powers of two so it divides GLM-5's attention-head count.)
-2. If nothing fits within the cap, the combo is **rejected** — distinguishing
+2. If nothing fits within the cap, the combo is **rejected** -- distinguishing
    "needs more than the cap (raise `--max-gpus`)" from "won't fit in VRAM at all".
 3. `cost = count * spot_price`.
 4. `auto` mode evaluates every GPU type and returns the minimum-cost fit.
@@ -129,31 +129,31 @@ Worked results under the default 4-GPU cap:
 
 | Quant | Cheapest pick | Count | TP | Est. spot $/hr | Notes |
 |-------|---------------|-------|----|----------------|-------|
-| **int4** (default) | **h200** | 4 | 4 | **~7.08** | a100/h100 excluded — would need 8 |
-| fp8 | _none at cap 4_ | — | — | — | needs ~860 GB (8 GPUs); `--max-gpus 8` → 8×h200 ~14.16 |
+| **int4** (default) | **h200** | 4 | 4 | **~7.08** | a100/h100 excluded -- would need 8 |
+| fp8 | _none at cap 4_ | -- | -- | -- | needs ~860 GB (8 GPUs); `--max-gpus 8` -> 8xh200 ~14.16 |
 
 Consequences of the 4-GPU target for GLM-5.2 (744B):
 
-- **A100 drops out.** At 80 GB/GPU, int4 needs 8×A100 — over the cap. The old
-  cheapest pick (8×A100, ~$5.28/hr) is only reachable with `--max-gpus 8`.
+- **A100 drops out.** At 80 GB/GPU, int4 needs 8xA100 -- over the cap. The old
+  cheapest pick (8xA100, ~$5.28/hr) is only reachable with `--max-gpus 8`.
 - **int4 is the de-facto only quant.** fp8 (~860 GB) cannot fit 4 GPUs of any
   tier; it is opt-in via `--max-gpus 8`, not part of the default menu.
-- **~$1.80/hr premium** over 8×A100, bought back as availability and single-node
-  performance — the explicit anti-corner trade.
+- **~$1.80/hr premium** over 8xA100, bought back as availability and single-node
+  performance -- the explicit anti-corner trade.
 
-`--gpu a100 --quant fp8` is still refused outright (8×80 GB = 640 GB < 860 GB).
+`--gpu a100 --quant fp8` is still refused outright (8x80 GB = 640 GB < 860 GB).
 
 ### Model Cache (`lib/modelcache.sh` + `container/fetch-model.sh`)
 
-The cache key sanitizes the model id: `zai-org/GLM-5.2` → `zai-org__GLM-5.2`.
+The cache key sanitizes the model id: `zai-org/GLM-5.2` -> `zai-org__GLM-5.2`.
 The bucket URI is `${REMVLLM_BUCKET_URL%/}/models/<key>/`.
 
 On node bootstrap, `fetch-model.sh`:
 
 1. Probe the bucket for `models/<key>/`.
-2. **Hit:** `rclone copy` (R2/S3 via `rclone` or `aws --endpoint-url`) bucket →
+2. **Hit:** `rclone copy` (R2/S3 via `rclone` or `aws --endpoint-url`) bucket ->
    local model dir. No HF traffic.
-3. **Miss:** `hf download <model-id>` → local, then **upload** to the bucket to
+3. **Miss:** `hf download <model-id>` -> local, then **upload** to the bucket to
    populate it for every future node. HF is touched this once.
 
 Because re-provisioning after a spot preemption is a cache *hit*, recovery is a
@@ -178,10 +178,10 @@ cloud-init installs podman + nvidia-container-toolkit and runs the appliance.
 
 | Service | Purpose |
 |---------|---------|
-| `fetch-model.sh` | Populate the model dir from bucket (or HF→bucket) before serve |
+| `fetch-model.sh` | Populate the model dir from bucket (or HF->bucket) before serve |
 | `vllm serve` | OpenAI-compatible API on `:8000` (`--tensor-parallel-size`, `--enable-expert-parallel`) |
 | `sshd` | Tunnel access |
-| `watchdog` | Server-side idle → self-destruct |
+| `watchdog` | Server-side idle -> self-destruct |
 
 ### CLI (`bin/remvllm`)
 
@@ -221,7 +221,7 @@ remvllm list-recipes
 
 ---
 
-## Data Model — `state/<hostname>/state.json`
+## Data Model -- `state/<hostname>/state.json`
 
 ```
 state.json
@@ -243,11 +243,11 @@ state.json
 
 ## Security Considerations
 
-- **Transport** — SSH tunnel only; vLLM binds to localhost on the remote, exposed
+- **Transport** -- SSH tunnel only; vLLM binds to localhost on the remote, exposed
   to the laptop over the tunnel. Only port 22 reachable.
-- **Secrets** — provider token, SSH keys, **bucket credentials**, and the HF token
+- **Secrets** -- provider token, SSH keys, **bucket credentials**, and the HF token
   come from 1Password (`op`) at runtime; never written to disk.
-- **Bucket** — private bucket, scoped credentials. Weights are public (MIT) but the
+- **Bucket** -- private bucket, scoped credentials. Weights are public (MIT) but the
   credential is not.
 
 ---
@@ -257,8 +257,8 @@ state.json
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | Engine | vLLM | Documented GLM-5 recipe; native OpenAI API; TP + expert parallel for MoE |
-| Default quant | int4 (AWQ) | Cheapest fit; 1–3% coding regression accepted for price |
-| Default GPU | auto → cheapest within cap | Penny-pinching, bounded by the platform ceiling |
+| Default quant | int4 (AWQ) | Cheapest fit; 1-3% coding regression accepted for price |
+| Default GPU | auto -> cheapest within cap | Penny-pinching, bounded by the platform ceiling |
 | GPU ceiling | 4 (single node) | NVLink, schedulable on spot; avoids betting on scarce 8-GPU boxes |
 | Spot | on by default | Cheapest per hour; preemption acceptable |
 | Weight cache | R2 default | Zero egress beats S3 on repeated multi-hundred-GB pulls |
@@ -269,24 +269,24 @@ state.json
 
 ## Open Questions
 
-1. **Exact TP/head divisibility for GLM-5.2** — TP is constrained to {1,2,4,8};
+1. **Exact TP/head divisibility for GLM-5.2** -- TP is constrained to {1,2,4,8};
    confirm against the published config before first real run.
-2. **Quant artifact source** — pull a prebuilt AWQ/FP8 checkpoint, or quantize once
+2. **Quant artifact source** -- pull a prebuilt AWQ/FP8 checkpoint, or quantize once
    and cache the quantized weights in the bucket? Caching quantized is cheaper to
    serve and smaller to pull. Leaning: cache the quantized artifact under a distinct
    key.
-3. **vLLM cold-load time** — large MoE load + KV warmup can exceed the SSH-probe
+3. **vLLM cold-load time** -- large MoE load + KV warmup can exceed the SSH-probe
    window; health-poll budget may need raising.
 
 ## Rejections
 
-- **Ollama / llama.cpp** — wrong engine for a 744B MoE at long context; no native
+- **Ollama / llama.cpp** -- wrong engine for a 744B MoE at long context; no native
   expert parallelism, weaker throughput.
-- **Single "big GPU" instance** — no single GPU holds the model even at int4
+- **Single "big GPU" instance** -- no single GPU holds the model even at int4
   (~430 GB > 141 GB H200). Multi-GPU is mandatory.
-- **S3 as default cache** — egress fees on repeated cold pulls defeat the
+- **S3 as default cache** -- egress fees on repeated cold pulls defeat the
   penny-pinching goal; R2 egress is free.
-- **On-demand instances by default** — 2–3× the spot price for a workload that
+- **On-demand instances by default** -- 2-3x the spot price for a workload that
   explicitly tolerates preemption.
 
 ## Future Considerations
@@ -297,4 +297,4 @@ state.json
 
 ## Related Documents
 
-- [REMOLLAMA.DESIGN.md](./REMOLLAMA.DESIGN.md) — the single-GPU Ollama sister tool
+- [REMOLLAMA.DESIGN.md](./REMOLLAMA.DESIGN.md) -- the single-GPU Ollama sister tool

--- a/docs/design/REMVLLM.DESIGN.md
+++ b/docs/design/REMVLLM.DESIGN.md
@@ -277,6 +277,18 @@ state.json
    key.
 3. **vLLM cold-load time** -- large MoE load + KV warmup can exceed the SSH-probe
    window; health-poll budget may need raising.
+4. **Appliance config + secret delivery (KNOWN GAP, deferred).** The container
+   needs runtime config (`MODEL_ID`, `QUANT`, `TENSOR_PARALLEL_SIZE`,
+   `SERVED_NAME`, `MAX_MODEL_LEN`, bucket URI) and secrets (HF token, bucket
+   credentials), but `bootstrap.sh` currently passes only `SSH_PUBLIC_KEY` -- so
+   the appliance will not start as wired today. The provisioning path is still
+   untested scaffolding, so this is deferred rather than built. Preferred fix
+   when we implement it: the orchestrator SSHes in post-provision and runs
+   `podman run` with env + secrets at that moment, keeping secrets OUT of
+   Terraform state and cloud-init/user_data (consistent with the Security
+   Considerations section). Baking secrets into `user_data` is rejected for the
+   at-rest leak. Until then, `remvllm run` provisions a node but the appliance is
+   non-functional. (Raised in PR #64 review.)
 
 ## Rejections
 

--- a/docs/design/REMVLLM.DESIGN.md
+++ b/docs/design/REMVLLM.DESIGN.md
@@ -1,0 +1,283 @@
+# remvllm — Remote vLLM Orchestrator (GLM-5.2 endpoint)
+
+> **Status:** Design / Pre-Implementation
+> **Created:** 2026-06-17
+> **Location:** `ops/terraform/remvllm/`
+> **Entry Point:** `bin/remvllm`
+> **Sister to:** [REMOLLAMA.DESIGN.md](./REMOLLAMA.DESIGN.md)
+
+---
+
+## Overview
+
+`remvllm` is the sister tool to `remollama`. Where `remollama` runs Ollama on a
+single GPU, `remvllm` provisions a **multi-GPU spot node**, serves a large
+open-weight model with **vLLM**, and exposes an **OpenAI-compatible API** on
+`localhost` via SSH tunnel. The first-class target is **GLM-5.2** — a 744B-param
+MoE (~40B active, 1M context, MIT license, weights at `zai-org/GLM-5.2`) that is
+far too large for Ollama-on-one-GPU.
+
+Two hard constraints drive the design:
+
+1. **Cheapest possible per hour.** Spot/preemptible instances by default, lowest
+   viable quant by default, cheapest GPU that fits. Preemption is acceptable.
+2. **Download the weights from Hugging Face exactly once.** Weights are cached in
+   an object bucket (Cloudflare **R2** by default — zero egress). Every node pulls
+   from the bucket; HF is only ever hit to *populate* the cache.
+
+---
+
+## Goals
+
+1. **One-command endpoint** — `remvllm run glm-5.2` yields an OpenAI-compatible
+   API at `localhost:<port>` speaking `/v1/chat/completions`.
+2. **Cheapest by default** — the sizer picks the lowest-cost spot config that fits
+   the chosen quant; `remvllm sizes` shows the cost matrix.
+3. **HF downloaded once** — after the first cold start, all weights come from the
+   bucket. Verifiable: a second cold start makes zero HF requests.
+4. **Selectable GPU and quant** — `--gpu` and `--quant` override the auto pick;
+   invalid combos (won't fit in VRAM) are refused with an actionable message.
+5. **Preemption-tolerant** — a reclaimed spot node is detected on the next `run`
+   and re-provisioned cheaply (weights already in the bucket).
+6. **Belt-and-suspenders spend control** — client TTL watchdog + server idle
+   watchdog, inherited from the remollama model.
+
+---
+
+## Non-Goals
+
+- **Replacing remollama** — remollama stays the right tool for small models on one
+  GPU. remvllm is for big MoE models that need tensor + expert parallelism.
+- **Training / fine-tuning** — inference serving only.
+- **Multi-user / shared serving** — single operator, SSH-tunnel access only.
+- **Guaranteeing availability** — spot nodes get reclaimed; that is the accepted
+  trade for price. We optimize fast recovery, not zero downtime.
+
+---
+
+## Architecture Overview
+
+```
++------------------------------------------------------------------+
+|  CLI Layer                                     bin/remvllm        |
+|  Parse args, load config, dispatch to orchestration               |
++------------------------------------------------------------------+
+|  Orchestration Layer                           lib/               |
+|  Lifecycle, state, TTL, sizing, model-cache sync, SSH tunnels      |
++------------------------------------------------------------------+
+|  Provisioning Layer                            modules/<provider> |
+|  Terraform — one module per cloud provider                        |
+|  Contract: "get me N GPUs of type T on a SPOT node, with podman"  |
++------------------------------------------------------------------+
+|  Runtime Layer                                 container/         |
+|  The remvllm appliance container                                  |
+|  fetch-model + vLLM + sshd + watchdog — identical everywhere      |
++------------------------------------------------------------------+
+                              |
+                              v
++------------------------------------------------------------------+
+|  Object bucket (R2 default / S3)   models/<sanitized-id>/         |
+|  Write-once weight cache. HF is hit only to populate it.          |
++------------------------------------------------------------------+
+```
+
+`remvllm` deliberately reuses remollama's module/lib/container/state shape. The
+differences are concentrated in three places: the **engine** (vLLM, not Ollama),
+the **sizer** (multi-GPU, cost-driven), and the **model cache** (bucket-backed).
+
+---
+
+## Design
+
+### Sizing Layer (`lib/sizing.sh`) — the penny-pincher
+
+The sizer answers: *given a quant and (optionally) a GPU type, what is the
+cheapest spot configuration that fits, and will it fit at all?*
+
+It is data-driven from tunable tables (prices are spot $/hr estimates, Spheron,
+2026-06 — easy to edit as the market moves):
+
+| GPU | VRAM/GPU | Spot $/hr | On-demand $/hr |
+|-----|----------|-----------|----------------|
+| a100 | 80 GB | 0.66 | 1.10 |
+| h100 | 80 GB | 1.43 | 2.53 |
+| h200 | 141 GB | 1.77 | 4.84 |
+| b200 | 180 GB | 2.99 | 5.50 |
+
+| Quant | Required VRAM (weights + KV/activation overhead, estimate) |
+|-------|------------------------------------------------------------|
+| int4 (AWQ) | ~430 GB |
+| fp8 | ~860 GB |
+
+Algorithm:
+
+1. `count = smallest valid tensor-parallel size in {1,2,4,8} such that
+   count * vram_per_gpu >= required_vram`. (TP is constrained to powers of two so
+   it divides GLM-5's attention-head count.)
+2. If no valid TP fits, that (quant, gpu) combo is **rejected**.
+3. `cost = count * spot_price`.
+4. `auto` mode evaluates every GPU type and returns the minimum-cost fit.
+
+Worked results from the tables above:
+
+| Quant | Cheapest pick | Count | TP | Est. spot $/hr |
+|-------|---------------|-------|----|----------------|
+| **int4** (default) | **a100** | 8 | 8 | **~5.28** |
+| fp8 | h200 | 8 | 8 | ~14.16 |
+
+`--gpu a100 --quant fp8` is correctly refused (8×80 GB = 640 GB < 860 GB).
+
+### Model Cache (`lib/modelcache.sh` + `container/fetch-model.sh`)
+
+The cache key sanitizes the model id: `zai-org/GLM-5.2` → `zai-org__GLM-5.2`.
+The bucket URI is `${REMVLLM_BUCKET_URL%/}/models/<key>/`.
+
+On node bootstrap, `fetch-model.sh`:
+
+1. Probe the bucket for `models/<key>/`.
+2. **Hit:** `rclone copy` (R2/S3 via `rclone` or `aws --endpoint-url`) bucket →
+   local model dir. No HF traffic.
+3. **Miss:** `hf download <model-id>` → local, then **upload** to the bucket to
+   populate it for every future node. HF is touched this once.
+
+Because re-provisioning after a spot preemption is a cache *hit*, recovery is a
+fast bucket pull, not a multi-hundred-GB HF re-download. This is what makes
+"cheapest, even if we get booted" practical.
+
+### Provisioning Layer (`modules/spheron/`)
+
+Terraform module honoring the provider-agnostic contract (same as remollama, plus
+multi-GPU + spot):
+
+| Direction | Field | Notes |
+|-----------|-------|-------|
+| In | `gpu_type`, `gpu_count` | from the sizer |
+| In | `spot` (default `true`), `max_price` | cheapest-first |
+| In | `container_image`, `ssh_public_key`, `provider_token`, `env_vars` | |
+| Out | `host`, `ssh_port`, `instance_id` | |
+
+cloud-init installs podman + nvidia-container-toolkit and runs the appliance.
+
+### Runtime Layer (`container/`)
+
+| Service | Purpose |
+|---------|---------|
+| `fetch-model.sh` | Populate the model dir from bucket (or HF→bucket) before serve |
+| `vllm serve` | OpenAI-compatible API on `:8000` (`--tensor-parallel-size`, `--enable-expert-parallel`) |
+| `sshd` | Tunnel access |
+| `watchdog` | Server-side idle → self-destruct |
+
+### CLI (`bin/remvllm`)
+
+```
+remvllm run <recipe>  [--gpu <type>] [--quant fp8|int4] [--ttl <min>] [--no-spot]
+remvllm stop          # close tunnel; node lives until TTL / preemption
+remvllm destroy       # terraform destroy now
+remvllm status        # node state, TTL, recipe, cost estimate
+remvllm sizes [--quant q]   # print the cost matrix and the auto pick
+remvllm cache <recipe>      # warm the bucket from HF without serving
+remvllm list-recipes
+```
+
+---
+
+## State Machine
+
+```
++--------+   run (cache miss)   +-------------+   serve ready   +---------+
+| ABSENT |--------------------->| PROVISIONING|---------------->| RUNNING |
++--------+                      +-------------+                 +---------+
+    ^   ^                                                        |  |   |
+    |   |  destroy / TTL expiry / preemption detected            |  |   |
+    |   +--------------------------------------------------------+  |   |
+    |                          stop (tunnel only)                   |   |
+    +---------------------------------------------------------------+   |
+    |                    spot preemption (node gone)                    |
+    +-------------------------------------------------------------------+
+```
+
+| From | To | Trigger | Condition |
+|------|----|---------|-----------|
+| ABSENT | PROVISIONING | `run` | no live node in state |
+| PROVISIONING | RUNNING | vLLM `/health` ok | tunnel established |
+| RUNNING | ABSENT | `destroy` / TTL / preemption | idle or user action |
+| RUNNING | RUNNING | `run` | warm reconnect, extend TTL |
+
+---
+
+## Data Model — `state/<hostname>/state.json`
+
+```
+state.json
++-- instance_id      provider instance id
++-- provider         "spheron"
++-- host / ssh_port  tunnel target
++-- gpu_type/count    sized config
++-- quant            "int4" | "fp8"
++-- recipe           "glm-5.2"
++-- spot             bool
++-- est_cost_hr      number (USD)
++-- created_at / ttl_expires_at
++-- tunnel_pid / status
+```
+
+`state/` is `.gitignore`d, partitioned per hostname.
+
+---
+
+## Security Considerations
+
+- **Transport** — SSH tunnel only; vLLM binds to localhost on the remote, exposed
+  to the laptop over the tunnel. Only port 22 reachable.
+- **Secrets** — provider token, SSH keys, **bucket credentials**, and the HF token
+  come from 1Password (`op`) at runtime; never written to disk.
+- **Bucket** — private bucket, scoped credentials. Weights are public (MIT) but the
+  credential is not.
+
+---
+
+## Key Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Engine | vLLM | Documented GLM-5 recipe; native OpenAI API; TP + expert parallel for MoE |
+| Default quant | int4 (AWQ) | Cheapest fit; 1–3% coding regression accepted for price |
+| Default GPU | auto → cheapest | Penny-pinching is the explicit requirement |
+| Spot | on by default | Cheapest per hour; preemption acceptable |
+| Weight cache | R2 default | Zero egress beats S3 on repeated multi-hundred-GB pulls |
+| HF policy | populate-once | Bucket hit on every node after the first cold start |
+| Tool shape | sister to remollama | Reuse module/lib/container/state skeleton; engine/sizer/cache differ |
+
+---
+
+## Open Questions
+
+1. **Exact TP/head divisibility for GLM-5.2** — TP is constrained to {1,2,4,8};
+   confirm against the published config before first real run.
+2. **Quant artifact source** — pull a prebuilt AWQ/FP8 checkpoint, or quantize once
+   and cache the quantized weights in the bucket? Caching quantized is cheaper to
+   serve and smaller to pull. Leaning: cache the quantized artifact under a distinct
+   key.
+3. **vLLM cold-load time** — large MoE load + KV warmup can exceed the SSH-probe
+   window; health-poll budget may need raising.
+
+## Rejections
+
+- **Ollama / llama.cpp** — wrong engine for a 744B MoE at long context; no native
+  expert parallelism, weaker throughput.
+- **Single "big GPU" instance** — no single GPU holds the model even at int4
+  (~430 GB > 141 GB H200). Multi-GPU is mandatory.
+- **S3 as default cache** — egress fees on repeated cold pulls defeat the
+  penny-pinching goal; R2 egress is free.
+- **On-demand instances by default** — 2–3× the spot price for a workload that
+  explicitly tolerates preemption.
+
+## Future Considerations
+
+- **SGLang** as an alternate engine (`--enable-moe-ep`) behind the same recipe.
+- **WireGuard/Tailscale** instead of SSH tunnel if it becomes a bottleneck.
+- **Shared lib with remollama** once remollama is actually built.
+
+## Related Documents
+
+- [REMOLLAMA.DESIGN.md](./REMOLLAMA.DESIGN.md) — the single-GPU Ollama sister tool

--- a/docs/design/REMVLLM.DESIGN.md
+++ b/docs/design/REMVLLM.DESIGN.md
@@ -109,23 +109,39 @@ It is data-driven from tunable tables (prices are spot $/hr estimates, Spheron,
 | int4 (AWQ) | ~430 GB |
 | fp8 | ~860 GB |
 
+**Target platform: a 4-GPU single node.** `REMVLLM_MAX_GPUS` (default **4**) caps
+the configuration. Four GPUs on one node sit on NVLink (no cross-node fabric),
+serve MoE inference better than 8, and — critically — are routinely schedulable
+on spot, where 8-GPU boxes are scarce and preemption-prone. Designing to 4 keeps
+us out of that corner. `--max-gpus 8` overrides for the rare fp8 run.
+
 Algorithm:
 
 1. `count = smallest valid tensor-parallel size in {1,2,4,8} such that
-   count * vram_per_gpu >= required_vram`. (TP is constrained to powers of two so
-   it divides GLM-5's attention-head count.)
-2. If no valid TP fits, that (quant, gpu) combo is **rejected**.
+   count * vram_per_gpu >= required_vram AND count <= REMVLLM_MAX_GPUS`. (TP is
+   constrained to powers of two so it divides GLM-5's attention-head count.)
+2. If nothing fits within the cap, the combo is **rejected** — distinguishing
+   "needs more than the cap (raise `--max-gpus`)" from "won't fit in VRAM at all".
 3. `cost = count * spot_price`.
 4. `auto` mode evaluates every GPU type and returns the minimum-cost fit.
 
-Worked results from the tables above:
+Worked results under the default 4-GPU cap:
 
-| Quant | Cheapest pick | Count | TP | Est. spot $/hr |
-|-------|---------------|-------|----|----------------|
-| **int4** (default) | **a100** | 8 | 8 | **~5.28** |
-| fp8 | h200 | 8 | 8 | ~14.16 |
+| Quant | Cheapest pick | Count | TP | Est. spot $/hr | Notes |
+|-------|---------------|-------|----|----------------|-------|
+| **int4** (default) | **h200** | 4 | 4 | **~7.08** | a100/h100 excluded — would need 8 |
+| fp8 | _none at cap 4_ | — | — | — | needs ~860 GB (8 GPUs); `--max-gpus 8` → 8×h200 ~14.16 |
 
-`--gpu a100 --quant fp8` is correctly refused (8×80 GB = 640 GB < 860 GB).
+Consequences of the 4-GPU target for GLM-5.2 (744B):
+
+- **A100 drops out.** At 80 GB/GPU, int4 needs 8×A100 — over the cap. The old
+  cheapest pick (8×A100, ~$5.28/hr) is only reachable with `--max-gpus 8`.
+- **int4 is the de-facto only quant.** fp8 (~860 GB) cannot fit 4 GPUs of any
+  tier; it is opt-in via `--max-gpus 8`, not part of the default menu.
+- **~$1.80/hr premium** over 8×A100, bought back as availability and single-node
+  performance — the explicit anti-corner trade.
+
+`--gpu a100 --quant fp8` is still refused outright (8×80 GB = 640 GB < 860 GB).
 
 ### Model Cache (`lib/modelcache.sh` + `container/fetch-model.sh`)
 
@@ -242,7 +258,8 @@ state.json
 |----------|--------|-----------|
 | Engine | vLLM | Documented GLM-5 recipe; native OpenAI API; TP + expert parallel for MoE |
 | Default quant | int4 (AWQ) | Cheapest fit; 1–3% coding regression accepted for price |
-| Default GPU | auto → cheapest | Penny-pinching is the explicit requirement |
+| Default GPU | auto → cheapest within cap | Penny-pinching, bounded by the platform ceiling |
+| GPU ceiling | 4 (single node) | NVLink, schedulable on spot; avoids betting on scarce 8-GPU boxes |
 | Spot | on by default | Cheapest per hour; preemption acceptable |
 | Weight cache | R2 default | Zero egress beats S3 on repeated multi-hundred-GB pulls |
 | HF policy | populate-once | Bucket hit on every node after the first cold start |

--- a/ops/terraform/remvllm/.gitignore
+++ b/ops/terraform/remvllm/.gitignore
@@ -1,0 +1,7 @@
+# Per-hostname runtime state and machine-specific config — never committed.
+state/
+remvllm.local.conf
+*.tfstate
+*.tfstate.backup
+.terraform/
+.terraform.lock.hcl

--- a/ops/terraform/remvllm/container/Containerfile
+++ b/ops/terraform/remvllm/container/Containerfile
@@ -1,0 +1,24 @@
+# Containerfile — the remvllm appliance: fetch-model + vLLM + sshd + watchdog.
+#
+# Identical image everywhere it runs. Build & push:
+#   podman build -t ghcr.io/9atatimer/remvllm-appliance:latest container/
+#   podman push   ghcr.io/9atatimer/remvllm-appliance:latest
+FROM vllm/vllm-openai:latest
+
+# Tunnel access + bucket transfer tooling.
+#   openssh-server : sshd for the SSH tunnel
+#   rclone         : R2/S3 weight transfer (zero-config endpoints)
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends openssh-server rclone curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /var/run/sshd /models
+
+COPY entrypoint.sh  /usr/local/bin/entrypoint.sh
+COPY fetch-model.sh /usr/local/bin/fetch-model.sh
+COPY watchdog.sh    /usr/local/bin/watchdog.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh \
+             /usr/local/bin/fetch-model.sh \
+             /usr/local/bin/watchdog.sh
+
+EXPOSE 22 8000
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/ops/terraform/remvllm/container/Containerfile
+++ b/ops/terraform/remvllm/container/Containerfile
@@ -7,9 +7,10 @@ FROM vllm/vllm-openai:latest
 
 # Tunnel access + bucket transfer tooling.
 #   openssh-server : sshd for the SSH tunnel
+#   iproute2       : provides `ss`, used by the watchdog to count SSH sessions
 #   rclone         : R2/S3 weight transfer (zero-config endpoints)
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends openssh-server rclone curl \
+    && apt-get install -y --no-install-recommends openssh-server iproute2 rclone curl \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir -p /var/run/sshd /models
 

--- a/ops/terraform/remvllm/container/entrypoint.sh
+++ b/ops/terraform/remvllm/container/entrypoint.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# entrypoint.sh — PID 1 supervisor for the remvllm appliance.
+#
+# Order: install SSH key -> start sshd -> fetch model -> start watchdog ->
+# exec vLLM (so vLLM is PID 1's foreground child and signals propagate).
+#
+# Environment (injected at run time):
+#   SSH_PUBLIC_KEY, MODEL_ID, QUANT, MODEL_BUCKET_URI, HF_TOKEN,
+#   TENSOR_PARALLEL_SIZE, SERVED_NAME, MAX_MODEL_LEN, EXTRA_ARGS,
+#   WATCHDOG_TIMEOUT, REMOTE_PORT
+set -euo pipefail
+
+start_sshd() {
+    mkdir -p /root/.ssh
+    printf '%s\n' "${SSH_PUBLIC_KEY}" > /root/.ssh/authorized_keys
+    chmod 700 /root/.ssh
+    chmod 600 /root/.ssh/authorized_keys
+    /usr/sbin/sshd
+}
+
+start_watchdog() {
+    WATCHDOG_TIMEOUT="${WATCHDOG_TIMEOUT:-600}" /usr/local/bin/watchdog.sh &
+}
+
+quant_args() {
+    case "${QUANT:-int4}" in
+        int4) printf -- '--quantization awq' ;;
+        fp8)  printf -- '--quantization fp8' ;;
+        *)    printf '' ;;
+    esac
+}
+
+serve_vllm() {
+    local model_dir
+    model_dir="$(/usr/local/bin/fetch-model.sh | tail -n1)"
+    # vLLM binds to localhost; the SSH tunnel is the only access path.
+    # shellcheck disable=SC2086
+    exec python3 -m vllm.entrypoints.openai.api_server \
+        --model "${model_dir}" \
+        --served-model-name "${SERVED_NAME:-glm-5.2}" \
+        --tensor-parallel-size "${TENSOR_PARALLEL_SIZE:-1}" \
+        --max-model-len "${MAX_MODEL_LEN:-131072}" \
+        --host 127.0.0.1 --port "${REMOTE_PORT:-8000}" \
+        $(quant_args) ${EXTRA_ARGS:-}
+}
+
+main() {
+    start_sshd
+    start_watchdog
+    serve_vllm
+}
+
+main "$@"

--- a/ops/terraform/remvllm/container/entrypoint.sh
+++ b/ops/terraform/remvllm/container/entrypoint.sh
@@ -31,6 +31,13 @@ quant_args() {
 }
 
 serve_vllm() {
+    # Fail fast on an unsupported quant rather than silently launching vLLM
+    # unquantized (which would OOM the GPUs). Validated here in the main shell
+    # so the exit propagates -- quant_args runs inside $(...) where it would not.
+    case "${QUANT:-int4}" in
+        int4|fp8) ;;
+        *) echo "fatal: unsupported QUANT='${QUANT:-}' (expected int4 or fp8)" >&2; exit 1 ;;
+    esac
     local model_dir
     model_dir="$(/usr/local/bin/fetch-model.sh | tail -n1)"
     # vLLM binds to localhost; the SSH tunnel is the only access path.

--- a/ops/terraform/remvllm/container/fetch-model.sh
+++ b/ops/terraform/remvllm/container/fetch-model.sh
@@ -23,13 +23,16 @@ bucket_has_weights() {
     #   unreachable / misconfigured -> FATAL (exit 1)
     # The fatal case is the point: if we silently treated an unreachable bucket
     # as a miss, we'd re-download from HF and break the "HF only once" guarantee.
-    local listing
-    if listing="$(rclone lsf "${MODEL_BUCKET_URI}" 2>/tmp/rclone-lsf.err)"; then
+    local listing errfile
+    errfile="$(mktemp)"
+    if listing="$(rclone lsf "${MODEL_BUCKET_URI}" 2>"${errfile}")"; then
+        rm -f "${errfile}"
         [[ -n "${listing}" ]]
     else
         echo "fatal: weight bucket ${MODEL_BUCKET_URI} is unreachable/misconfigured" >&2
         echo "       (refusing to fall back to Hugging Face; fix bucket access and retry)" >&2
-        cat /tmp/rclone-lsf.err >&2 || true
+        cat "${errfile}" >&2 || true
+        rm -f "${errfile}"
         exit 1
     fi
 }
@@ -40,6 +43,11 @@ pull_from_bucket() {
 }
 
 download_from_hf() {
+    if [[ -z "${HF_TOKEN:-}" ]]; then
+        echo "fatal: HF_TOKEN is not set; cannot download ${MODEL_ID} from Hugging Face" >&2
+        echo "       (set HF_TOKEN, or pre-populate the weight bucket so this is a cache hit)" >&2
+        exit 1
+    fi
     echo "cache MISS: downloading ${MODEL_ID} from Hugging Face (one time only)"
     HF_HUB_ENABLE_HF_TRANSFER=1 \
         huggingface-cli download "${MODEL_ID}" --local-dir "${MODEL_DIR}" --token "${HF_TOKEN}"

--- a/ops/terraform/remvllm/container/fetch-model.sh
+++ b/ops/terraform/remvllm/container/fetch-model.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# fetch-model.sh — populate /models from the bucket, or HF -> bucket once.
+#
+# THE GUARANTEE: Hugging Face is hit only to populate the bucket. Every node
+# after the first cold start pulls weights from the bucket (a cache hit).
+#
+# Environment (injected by the orchestrator via the appliance):
+#   MODEL_ID          e.g. zai-org/GLM-5.2
+#   QUANT             int4 | fp8
+#   MODEL_BUCKET_URI  rclone remote:path, e.g. r2:remvllm-weights/models/zai-org__GLM-5.2/int4
+#   RCLONE_CONFIG_*   rclone remote config (R2/S3 endpoint + creds)
+#   HF_TOKEN          Hugging Face token (only used on a cache miss)
+set -euo pipefail
+
+MODEL_DIR="/models/current"
+
+# --- Action functions --------------------------------------------------------
+
+bucket_has_weights() {
+    # rclone lsf returns the listing; non-empty => cache hit.
+    [[ -n "$(rclone lsf "${MODEL_BUCKET_URI}" 2>/dev/null)" ]]
+}
+
+pull_from_bucket() {
+    echo "cache HIT: pulling weights from ${MODEL_BUCKET_URI}"
+    rclone copy --transfers 16 --checkers 32 "${MODEL_BUCKET_URI}" "${MODEL_DIR}"
+}
+
+download_from_hf() {
+    echo "cache MISS: downloading ${MODEL_ID} from Hugging Face (one time only)"
+    HF_HUB_ENABLE_HF_TRANSFER=1 \
+        huggingface-cli download "${MODEL_ID}" --local-dir "${MODEL_DIR}" --token "${HF_TOKEN}"
+}
+
+populate_bucket() {
+    echo "populating bucket so HF is never hit again: ${MODEL_BUCKET_URI}"
+    rclone copy --transfers 16 --checkers 32 "${MODEL_DIR}" "${MODEL_BUCKET_URI}"
+}
+
+# --- Flow / Main -------------------------------------------------------------
+
+main() {
+    mkdir -p "${MODEL_DIR}"
+    if bucket_has_weights; then
+        pull_from_bucket
+    else
+        download_from_hf
+        populate_bucket
+    fi
+    echo "${MODEL_DIR}"
+}
+
+main "$@"

--- a/ops/terraform/remvllm/container/fetch-model.sh
+++ b/ops/terraform/remvllm/container/fetch-model.sh
@@ -17,8 +17,21 @@ MODEL_DIR="/models/current"
 # --- Action functions --------------------------------------------------------
 
 bucket_has_weights() {
-    # rclone lsf returns the listing; non-empty => cache hit.
-    [[ -n "$(rclone lsf "${MODEL_BUCKET_URI}" 2>/dev/null)" ]]
+    # Probe the bucket and distinguish three cases:
+    #   reachable + non-empty -> cache HIT  (return 0)
+    #   reachable + empty     -> cache MISS (return 1 -> HF fallback)
+    #   unreachable / misconfigured -> FATAL (exit 1)
+    # The fatal case is the point: if we silently treated an unreachable bucket
+    # as a miss, we'd re-download from HF and break the "HF only once" guarantee.
+    local listing
+    if listing="$(rclone lsf "${MODEL_BUCKET_URI}" 2>/tmp/rclone-lsf.err)"; then
+        [[ -n "${listing}" ]]
+    else
+        echo "fatal: weight bucket ${MODEL_BUCKET_URI} is unreachable/misconfigured" >&2
+        echo "       (refusing to fall back to Hugging Face; fix bucket access and retry)" >&2
+        cat /tmp/rclone-lsf.err >&2 || true
+        exit 1
+    fi
 }
 
 pull_from_bucket() {

--- a/ops/terraform/remvllm/container/watchdog.sh
+++ b/ops/terraform/remvllm/container/watchdog.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# watchdog.sh — server-side idle monitor (the "belt").
+#
+# If no SSH session is present for WATCHDOG_TIMEOUT seconds, the node has been
+# abandoned (e.g. the laptop slept and the client watchdog died). Self-destruct
+# to stop the spend. Spot reclaim is the other backstop.
+set -euo pipefail
+
+WATCHDOG_TIMEOUT="${WATCHDOG_TIMEOUT:-600}"
+POLL_INTERVAL=30
+
+active_ssh_sessions() {
+    # Count established inbound SSH connections (excludes the listener).
+    ss -tn state established '( sport = :22 )' 2>/dev/null | grep -c ':22 ' || true
+}
+
+main() {
+    local idle=0
+    while true; do
+        if [[ "$(active_ssh_sessions)" -gt 0 ]]; then
+            idle=0
+        else
+            idle=$((idle + POLL_INTERVAL))
+        fi
+        if (( idle >= WATCHDOG_TIMEOUT )); then
+            echo "watchdog: idle ${idle}s >= ${WATCHDOG_TIMEOUT}s — self-destructing"
+            shutdown -h now || poweroff -f || halt -f
+            exit 0
+        fi
+        sleep "${POLL_INTERVAL}"
+    done
+}
+
+main "$@"

--- a/ops/terraform/remvllm/container/watchdog.sh
+++ b/ops/terraform/remvllm/container/watchdog.sh
@@ -10,7 +10,14 @@ WATCHDOG_TIMEOUT="${WATCHDOG_TIMEOUT:-600}"
 POLL_INTERVAL=30
 
 active_ssh_sessions() {
-    # Count established inbound SSH connections (excludes the listener).
+    # Count established inbound SSH connections (excludes the listener). Always
+    # emit an integer. `ss` ships via iproute2 in the appliance image; if it is
+    # somehow missing we report 0 rather than an empty string (which would make
+    # the numeric comparison in main() fail under set -e).
+    if ! command -v ss >/dev/null 2>&1; then
+        echo 0
+        return 0
+    fi
     ss -tn state established '( sport = :22 )' 2>/dev/null | grep -c ':22 ' || true
 }
 

--- a/ops/terraform/remvllm/lib/config.sh
+++ b/ops/terraform/remvllm/lib/config.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# config.sh — layered configuration loader for remvllm.
+#
+# Precedence (lowest to highest): remvllm.conf < remvllm.local.conf < environment.
+# Prerequisites: bash 5.2+.
+# Side effects: exports REMVLLM_* variables into the environment.
+
+# --- Action functions --------------------------------------------------------
+
+# Snapshot every REMVLLM_* variable EXPORTED in the environment, so it can be
+# re-applied after the conf files load (environment wins). Only exported scalars
+# count as environment overrides — internal array tables (compgen -v) are skipped
+# by using compgen -e. Echoes "NAME=VALUE" lines, one per variable.
+config_env_snapshot() {
+    local name
+    while IFS= read -r name; do
+        printf '%s=%s\n' "${name}" "${!name-}"
+    done < <(compgen -e 2>/dev/null | grep -E '^REMVLLM_' || true)
+}
+
+# --- Flow functions ----------------------------------------------------------
+
+# Load config from <ops_dir>, honoring precedence. The environment snapshot is
+# captured BEFORE sourcing the conf files and re-applied AFTER, so any REMVLLM_*
+# set in the environment overrides both files.
+config_load() {
+    local ops_dir="$1"
+    local main_conf="${ops_dir}/remvllm.conf"
+    local local_conf="${ops_dir}/remvllm.local.conf"
+
+    local snapshot
+    snapshot="$(config_env_snapshot)"
+
+    if [[ -f "${main_conf}" ]]; then
+        # shellcheck disable=SC1090
+        source "${main_conf}"
+    else
+        echo "error: missing ${main_conf}" >&2
+        return 1
+    fi
+    if [[ -f "${local_conf}" ]]; then
+        # shellcheck disable=SC1090
+        source "${local_conf}"
+    fi
+
+    # Re-apply environment overrides (highest precedence).
+    local line name value
+    while IFS= read -r line; do
+        [[ -n "${line}" ]] || continue
+        name="${line%%=*}"
+        value="${line#*=}"
+        printf -v "${name}" '%s' "${value}"
+    done <<< "${snapshot}"
+
+    # Export scalars for child processes (terraform, ssh, etc.). Internal array
+    # tables (e.g. the sizing tables) cannot be exported and are skipped.
+    local v
+    while IFS= read -r v; do
+        case "$(declare -p "${v}" 2>/dev/null)" in
+            "declare -A"*|"declare -a"*) continue ;;
+        esac
+        export "${v?}"
+    done < <(compgen -v | grep -E '^REMVLLM_' || true)
+}

--- a/ops/terraform/remvllm/lib/modelcache.sh
+++ b/ops/terraform/remvllm/lib/modelcache.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# modelcache.sh — bucket-backed weight cache addressing for remvllm.
+#
+# The guarantee: download the weights from Hugging Face exactly once. These
+# helpers compute WHERE the weights live in the bucket; the actual transfer
+# (rclone/aws) runs on the node via container/fetch-model.sh, using the same
+# key scheme.
+# Prerequisites: none (pure string logic).
+# Side effects: none.
+
+# --- Action functions --------------------------------------------------------
+
+# Sanitize a model id into a filesystem/bucket-safe key.
+#   zai-org/GLM-5.2 -> zai-org__GLM-5.2
+modelcache_key() {
+    local model_id="$1"
+    printf '%s\n' "${model_id//\//__}"
+}
+
+# Echo the bucket URI (rclone-style remote:path) for a model id, optionally
+# namespaced by quant so a quantized artifact gets its own slot.
+#   modelcache_uri r2:weights zai-org/GLM-5.2        -> r2:weights/models/zai-org__GLM-5.2
+#   modelcache_uri r2:weights zai-org/GLM-5.2 int4   -> r2:weights/models/zai-org__GLM-5.2/int4
+modelcache_uri() {
+    local bucket_url="$1" model_id="$2" quant="${3:-}"
+    local key
+    key="$(modelcache_key "${model_id}")"
+    local uri="${bucket_url%/}/models/${key}"
+    [[ -n "${quant}" ]] && uri="${uri}/${quant}"
+    printf '%s\n' "${uri}"
+}

--- a/ops/terraform/remvllm/lib/orchestrate.sh
+++ b/ops/terraform/remvllm/lib/orchestrate.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# orchestrate.sh — lifecycle glue for remvllm (provision, connect, teardown).
+#
+# Sequences the other libs: sizing -> secrets -> terraform -> tunnel -> state.
+# This is the integration layer; it shells out to terraform, ssh, and op.
+# Prerequisites: terraform, ssh, op, jq, curl.
+# Side effects: provisions/destroys cloud infrastructure.
+
+# --- Action functions --------------------------------------------------------
+
+# Echo the terraform working dir for the active provider module.
+orchestrate_tf_dir() {
+    printf '%s/modules/%s\n' "${REMVLLM_OPS_DIR}" "${REMVLLM_PROVIDER}"
+}
+
+# Probe whether the node behind the current state is still alive (spot nodes get
+# reclaimed). Returns 0 if reachable over SSH.
+orchestrate_node_alive() {
+    local host="$1" ssh_port="$2" key_file="$3"
+    [[ -n "${host}" ]] || return 1
+    ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=8 -o BatchMode=yes \
+        -i "${key_file}" -p "${ssh_port}" "root@${host}" true 2>/dev/null
+}
+
+# --- Flow functions ----------------------------------------------------------
+
+# Provision (or reconnect to) a node serving `recipe`, then open the tunnel.
+# This is the body of `remvllm run`; it expects config to be loaded and the
+# resolved sizing in REMVLLM_PLAN ("gpu count tp cost").
+orchestrate_run() {
+    local recipe="$1"
+    local base="${REMVLLM_STATE_DIR:-${REMVLLM_OPS_DIR}/state}"
+
+    read -r gpu count tp cost <<< "${REMVLLM_PLAN}"
+
+    secrets_preflight
+
+    if state_has_instance "${base}"; then
+        local host ssh_port
+        host="$(state_read "${base}" host)"
+        ssh_port="$(state_read "${base}" ssh_port)"
+        if orchestrate_node_alive "${host}" "${ssh_port}" "${REMVLLM_KEY_FILE}"; then
+            echo "reconnecting to live ${gpu} x${count} node (${host})"
+            orchestrate_extend_ttl "${base}"
+            orchestrate_connect "${base}"
+            return 0
+        fi
+        echo "previous node is gone (spot reclaim?) — provisioning fresh"
+        state_clear "${base}"
+    fi
+
+    echo "provisioning ${count}x ${gpu} spot node for ${recipe} (~\$${cost}/hr) ..."
+    orchestrate_provision "${recipe}" "${gpu}" "${count}" "${tp}" "${cost}" "${base}"
+    orchestrate_connect "${base}"
+}
+
+# terraform apply with sized + secret inputs, then record state.
+orchestrate_provision() {
+    local recipe="$1" gpu="$2" count="$3" tp="$4" cost="$5" base="$6"
+    local tf_dir
+    tf_dir="$(orchestrate_tf_dir)"
+
+    terraform -chdir="${tf_dir}" init -input=false >/dev/null
+    terraform -chdir="${tf_dir}" apply -input=false -auto-approve \
+        -var "gpu_type=${gpu}" \
+        -var "gpu_count=${count}" \
+        -var "spot=${REMVLLM_SPOT}" \
+        -var "provider_token=$(secrets_provider_token)" \
+        -var "ssh_public_key=$(secrets_provider_ssh_pubkey)" \
+        -var "container_image=${REMVLLM_IMAGE:-ghcr.io/9atatimer/remvllm-appliance:latest}" \
+        -var "instance_name=remvllm-${recipe}"
+
+    local host ssh_port instance_id ttl
+    host="$(terraform -chdir="${tf_dir}" output -raw host)"
+    ssh_port="$(terraform -chdir="${tf_dir}" output -raw ssh_port)"
+    instance_id="$(terraform -chdir="${tf_dir}" output -raw instance_id)"
+    ttl="$(watchdog_ttl_from_now "${REMVLLM_TTL_MINUTES}")"
+
+    state_write "${base}" \
+        instance_id="${instance_id}" provider="${REMVLLM_PROVIDER}" \
+        host="${host}" ssh_port="${ssh_port}" \
+        gpu_type="${gpu}" gpu_count="${count}" tensor_parallel="${tp}" \
+        quant="${REMVLLM_QUANT}" recipe="${recipe}" spot="${REMVLLM_SPOT}" \
+        est_cost_hr="${cost}" ttl_expires_at="${ttl}" status="running"
+}
+
+# Open the tunnel and wait for the OpenAI-compatible endpoint to answer.
+orchestrate_connect() {
+    local base="$1"
+    local host ssh_port pid
+    host="$(state_read "${base}" host)"
+    ssh_port="$(state_read "${base}" ssh_port)"
+
+    pid="$(tunnel_open "${host}" "${ssh_port}" \
+        "${REMVLLM_LOCAL_PORT}" "${REMVLLM_REMOTE_PORT}" "${REMVLLM_KEY_FILE}")"
+    state_write_field "${base}" tunnel_pid "${pid:-null}"
+
+    echo "waiting for vLLM endpoint ..."
+    local i
+    for i in $(seq 1 120); do
+        if tunnel_endpoint_ready "${REMVLLM_LOCAL_PORT}"; then
+            echo "ready — OpenAI-compatible API at http://localhost:${REMVLLM_LOCAL_PORT}/v1"
+            return 0
+        fi
+        sleep 5
+    done
+    echo "error: endpoint did not become ready; check 'remvllm status' / node logs" >&2
+    return 1
+}
+
+# Merge a single field into existing state (read-modify-write).
+state_write_field() {
+    local base="$1" field="$2" value="$3"
+    local file
+    file="$(state_file "${base}")"
+    [[ -f "${file}" ]] || { echo "{}" > "${file}"; }
+    local tmp
+    tmp="$(mktemp)"
+    if [[ "${value}" =~ ^-?[0-9]+(\.[0-9]+)?$ || "${value}" == "true" || "${value}" == "false" || "${value}" == "null" ]]; then
+        jq ".${field} = ${value}" "${file}" > "${tmp}"
+    else
+        jq --arg v "${value}" ".${field} = \$v" "${file}" > "${tmp}"
+    fi
+    mv "${tmp}" "${file}"
+}
+
+orchestrate_extend_ttl() {
+    local base="$1"
+    state_write_field "${base}" ttl_expires_at "$(watchdog_ttl_from_now "${REMVLLM_TTL_MINUTES}")"
+}
+
+# Close the tunnel; leave the node to TTL/preemption.
+orchestrate_stop() {
+    local base="${REMVLLM_STATE_DIR:-${REMVLLM_OPS_DIR}/state}"
+    tunnel_kill "$(state_read "${base}" tunnel_pid)"
+    state_write_field "${base}" tunnel_pid null
+    echo "tunnel closed; node alive until TTL or spot reclaim. 'remvllm destroy' to kill now."
+}
+
+# Tear the node down immediately.
+orchestrate_destroy() {
+    local base="${REMVLLM_STATE_DIR:-${REMVLLM_OPS_DIR}/state}"
+    local tf_dir
+    tf_dir="$(orchestrate_tf_dir)"
+    tunnel_kill "$(state_read "${base}" tunnel_pid)"
+    if state_has_instance "${base}"; then
+        secrets_preflight
+        terraform -chdir="${tf_dir}" destroy -input=false -auto-approve \
+            -var "provider_token=$(secrets_provider_token)" >/dev/null
+    fi
+    state_clear "${base}"
+    echo "destroyed."
+}

--- a/ops/terraform/remvllm/lib/orchestrate.sh
+++ b/ops/terraform/remvllm/lib/orchestrate.sh
@@ -145,8 +145,22 @@ orchestrate_destroy() {
     tunnel_kill "$(state_read "${base}" tunnel_pid)"
     if state_has_instance "${base}"; then
         secrets_preflight
+        # terraform destroy still requires every declared variable to have a
+        # value. Reconstruct the create-time inputs from state + config/secrets
+        # so destroy doesn't abort with "No value for required variable".
+        local gpu count spot recipe
+        gpu="$(state_read "${base}" gpu_type)"
+        count="$(state_read "${base}" gpu_count)"
+        spot="$(state_read "${base}" spot)"
+        recipe="$(state_read "${base}" recipe)"
         terraform -chdir="${tf_dir}" destroy -input=false -auto-approve \
-            -var "provider_token=$(secrets_provider_token)" >/dev/null
+            -var "provider_token=$(secrets_provider_token)" \
+            -var "ssh_public_key=$(secrets_provider_ssh_pubkey)" \
+            -var "container_image=${REMVLLM_IMAGE:-ghcr.io/9atatimer/remvllm-appliance:latest}" \
+            -var "gpu_type=${gpu}" \
+            -var "gpu_count=${count}" \
+            -var "spot=${spot}" \
+            -var "instance_name=remvllm-${recipe}" >/dev/null
     fi
     state_clear "${base}"
     echo "destroyed."

--- a/ops/terraform/remvllm/lib/secrets.sh
+++ b/ops/terraform/remvllm/lib/secrets.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# secrets.sh — 1Password (op) secret resolution for remvllm.
+#
+# Secrets are read at runtime and piped into terraform/ssh/the appliance. They
+# are never written to disk.
+# Prerequisites: 1Password CLI (`op`) authenticated.
+# Side effects: shells out to `op read`.
+
+# --- Action functions --------------------------------------------------------
+
+# Resolve a single op:// reference, no trailing newline.
+secrets_read() {
+    local ref="$1"
+    [[ -n "${ref}" ]] || { echo "error: empty op:// reference" >&2; return 1; }
+    op read "${ref}" --no-newline
+}
+
+# Resolve the active provider's API token (e.g. REMVLLM_SPHERON_OP_TOKEN).
+secrets_provider_token() {
+    local var="REMVLLM_${REMVLLM_PROVIDER^^}_OP_TOKEN"
+    secrets_read "${!var:-}"
+}
+
+secrets_provider_ssh_key() {
+    local var="REMVLLM_${REMVLLM_PROVIDER^^}_OP_SSH_KEY"
+    secrets_read "${!var:-}"
+}
+
+secrets_provider_ssh_pubkey() {
+    local var="REMVLLM_${REMVLLM_PROVIDER^^}_OP_SSH_PUBKEY"
+    secrets_read "${!var:-}"
+}
+
+secrets_hf_token()        { secrets_read "${REMVLLM_OP_HF_TOKEN:-}"; }
+secrets_bucket_access()   { secrets_read "${REMVLLM_OP_BUCKET_ACCESS_KEY:-}"; }
+secrets_bucket_secret()   { secrets_read "${REMVLLM_OP_BUCKET_SECRET_KEY:-}"; }
+secrets_bucket_endpoint() { secrets_read "${REMVLLM_OP_BUCKET_ENDPOINT:-}"; }
+
+# --- Flow functions ----------------------------------------------------------
+
+# Verify `op` is available and authenticated; actionable error if not.
+secrets_preflight() {
+    if ! command -v op >/dev/null 2>&1; then
+        echo "error: 1Password CLI (op) not found. Install: brew install 1password-cli" >&2
+        return 1
+    fi
+    if ! op account list >/dev/null 2>&1; then
+        echo "error: op is not signed in. Run: eval \"\$(op signin)\"" >&2
+        return 1
+    fi
+}

--- a/ops/terraform/remvllm/lib/sizing.sh
+++ b/ops/terraform/remvllm/lib/sizing.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# sizing.sh — cost-driven multi-GPU sizing for remvllm.
+#
+# Purpose: given a quant and (optionally) a GPU type, compute the CHEAPEST spot
+#   configuration that fits the model in VRAM, or reject combos that cannot fit.
+# Prerequisites: bash 5.2+ (associative arrays), awk.
+# Side effects: none. Pure functions; source and call.
+#
+# All tables are tunable estimates (Spheron spot $/hr, 2026-06). Edit freely as
+# the market moves — the logic does not change.
+
+# --- Data tables -------------------------------------------------------------
+
+declare -gA REMVLLM_GPU_VRAM=(     [a100]=80  [h100]=80   [h200]=141  [b200]=180 )
+declare -gA REMVLLM_GPU_SPOT=(     [a100]=0.66 [h100]=1.43 [h200]=1.77 [b200]=2.99 )
+declare -gA REMVLLM_GPU_ONDEMAND=( [a100]=1.10 [h100]=2.53 [h200]=4.84 [b200]=5.50 )
+
+# Required total VRAM (weights + KV/activation overhead) per quant, in GB.
+# Estimates for GLM-5.2 (744B MoE). See REMVLLM.DESIGN.md.
+declare -gA REMVLLM_QUANT_VRAM=( [int4]=430 [fp8]=860 )
+
+# Tensor-parallel size is constrained to powers of two so it divides GLM-5's
+# attention-head count. Ascending — we want the smallest fit.
+REMVLLM_VALID_TP=(1 2 4 8)
+
+# Order GPUs cheapest-first only for tie-breaking; cost still decides.
+REMVLLM_GPU_TYPES=(a100 h100 h200 b200)
+
+# --- Action functions --------------------------------------------------------
+
+# Echo the smallest valid tensor-parallel GPU count that fits `quant` on
+# `gpu_type`. Returns non-zero (and echoes nothing) if no valid size fits.
+sizing_gpu_count() {
+    local quant="$1" gpu="$2"
+    local vram="${REMVLLM_GPU_VRAM[$gpu]:-}"
+    local required="${REMVLLM_QUANT_VRAM[$quant]:-}"
+    if [[ -z "${vram}" || -z "${required}" ]]; then
+        return 1
+    fi
+    local tp
+    for tp in "${REMVLLM_VALID_TP[@]}"; do
+        if (( tp * vram >= required )); then
+            printf '%s\n' "${tp}"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# Echo cost = count * price for a pricing model (spot|ondemand), 2 decimals.
+sizing_cost() {
+    local count="$1" gpu="$2" pricing="${3:-spot}"
+    local price
+    if [[ "${pricing}" == "ondemand" ]]; then
+        price="${REMVLLM_GPU_ONDEMAND[$gpu]:-}"
+    else
+        price="${REMVLLM_GPU_SPOT[$gpu]:-}"
+    fi
+    [[ -n "${price}" ]] || return 1
+    awk -v c="${count}" -v p="${price}" 'BEGIN { printf "%.2f", c * p }'
+}
+
+# --- Flow functions ----------------------------------------------------------
+
+# Plan a concrete sizing. Echoes "gpu_type count tp cost" on success.
+# Usage: sizing_plan <quant> <gpu_type|auto> [pricing]
+sizing_plan() {
+    local quant="$1" gpu="${2:-auto}" pricing="${3:-spot}"
+
+    if [[ "${gpu}" != "auto" ]]; then
+        local count
+        if ! count="$(sizing_gpu_count "${quant}" "${gpu}")"; then
+            echo "error: ${quant} will not fit on any valid GPU count of ${gpu}" >&2
+            echo "       (need ${REMVLLM_QUANT_VRAM[$quant]:-?} GB; ${gpu} = ${REMVLLM_GPU_VRAM[$gpu]:-?} GB/GPU, max TP ${REMVLLM_VALID_TP[-1]})" >&2
+            return 1
+        fi
+        local cost
+        cost="$(sizing_cost "${count}" "${gpu}" "${pricing}")"
+        printf '%s %s %s %s\n' "${gpu}" "${count}" "${count}" "${cost}"
+        return 0
+    fi
+
+    # auto: evaluate every GPU type, keep the minimum-cost fit.
+    local best_gpu="" best_count="" best_cost=""
+    local g count cost
+    for g in "${REMVLLM_GPU_TYPES[@]}"; do
+        count="$(sizing_gpu_count "${quant}" "${g}")" || continue
+        cost="$(sizing_cost "${count}" "${g}" "${pricing}")"
+        if [[ -z "${best_cost}" ]] || awk -v a="${cost}" -v b="${best_cost}" 'BEGIN { exit !(a < b) }'; then
+            best_gpu="${g}"; best_count="${count}"; best_cost="${cost}"
+        fi
+    done
+    if [[ -z "${best_gpu}" ]]; then
+        echo "error: ${quant} does not fit on any known GPU type" >&2
+        return 1
+    fi
+    printf '%s %s %s %s\n' "${best_gpu}" "${best_count}" "${best_count}" "${best_cost}"
+}
+
+# Render the full cost matrix for a quant (human-readable). Marks the auto pick.
+sizing_matrix() {
+    local quant="$1" pricing="${2:-spot}"
+    local pick g count cost
+    pick="$(sizing_plan "${quant}" auto "${pricing}" 2>/dev/null | awk '{print $1}')"
+    printf 'quant=%s  pricing=%s\n' "${quant}" "${pricing}"
+    printf '  %-6s %-6s %-6s %-10s\n' GPU COUNT TP "$(printf '$%s/hr' "${pricing}")"
+    for g in "${REMVLLM_GPU_TYPES[@]}"; do
+        if count="$(sizing_gpu_count "${quant}" "${g}")"; then
+            cost="$(sizing_cost "${count}" "${g}" "${pricing}")"
+            printf '  %-6s %-6s %-6s %-10s%s\n' \
+                "${g}" "${count}" "${count}" "${cost}" \
+                "$([[ "${g}" == "${pick}" ]] && printf '  <- cheapest' || true)"
+        else
+            printf '  %-6s %-6s %-6s %-10s\n' "${g}" "-" "-" "will not fit"
+        fi
+    done
+}

--- a/ops/terraform/remvllm/lib/sizing.sh
+++ b/ops/terraform/remvllm/lib/sizing.sh
@@ -23,15 +23,21 @@ declare -gA REMVLLM_QUANT_VRAM=( [int4]=430 [fp8]=860 )
 # attention-head count. Ascending — we want the smallest fit.
 REMVLLM_VALID_TP=(1 2 4 8)
 
+# Target-platform ceiling. 4-GPU single-node (NVLink, no cross-node fabric) is
+# the sweet spot: easy to schedule on spot, serves inference better than 8-GPU.
+# Combos that need more than this are refused unless overridden (--max-gpus).
+REMVLLM_MAX_GPUS_DEFAULT=4
+
 # Order GPUs cheapest-first only for tie-breaking; cost still decides.
 REMVLLM_GPU_TYPES=(a100 h100 h200 b200)
 
 # --- Action functions --------------------------------------------------------
 
-# Echo the smallest valid tensor-parallel GPU count that fits `quant` on
-# `gpu_type`. Returns non-zero (and echoes nothing) if no valid size fits.
-sizing_gpu_count() {
-    local quant="$1" gpu="$2"
+# Echo the smallest valid tensor-parallel GPU count (<= max_gpus) that fits
+# `quant` on `gpu_type`. Returns non-zero (and echoes nothing) if no valid size
+# fits within the cap. Internal: the cap is an explicit argument.
+sizing_count_within() {
+    local quant="$1" gpu="$2" max="$3"
     local vram="${REMVLLM_GPU_VRAM[$gpu]:-}"
     local required="${REMVLLM_QUANT_VRAM[$quant]:-}"
     if [[ -z "${vram}" || -z "${required}" ]]; then
@@ -39,12 +45,19 @@ sizing_gpu_count() {
     fi
     local tp
     for tp in "${REMVLLM_VALID_TP[@]}"; do
+        (( tp > max )) && break
         if (( tp * vram >= required )); then
             printf '%s\n' "${tp}"
             return 0
         fi
     done
     return 1
+}
+
+# Public: smallest count that fits within the active GPU cap
+# (REMVLLM_MAX_GPUS, default REMVLLM_MAX_GPUS_DEFAULT).
+sizing_gpu_count() {
+    sizing_count_within "$1" "$2" "${REMVLLM_MAX_GPUS:-${REMVLLM_MAX_GPUS_DEFAULT}}"
 }
 
 # Echo cost = count * price for a pricing model (spot|ondemand), 2 decimals.
@@ -67,11 +80,19 @@ sizing_cost() {
 sizing_plan() {
     local quant="$1" gpu="${2:-auto}" pricing="${3:-spot}"
 
+    local cap="${REMVLLM_MAX_GPUS:-${REMVLLM_MAX_GPUS_DEFAULT}}"
+
     if [[ "${gpu}" != "auto" ]]; then
-        local count
+        local count uncapped
         if ! count="$(sizing_gpu_count "${quant}" "${gpu}")"; then
-            echo "error: ${quant} will not fit on any valid GPU count of ${gpu}" >&2
-            echo "       (need ${REMVLLM_QUANT_VRAM[$quant]:-?} GB; ${gpu} = ${REMVLLM_GPU_VRAM[$gpu]:-?} GB/GPU, max TP ${REMVLLM_VALID_TP[-1]})" >&2
+            # Distinguish "over the GPU cap" from "won't fit in VRAM at all".
+            if uncapped="$(sizing_count_within "${quant}" "${gpu}" "${REMVLLM_VALID_TP[-1]}")"; then
+                echo "error: ${quant} on ${gpu} needs ${uncapped} GPUs, over the ${cap}-GPU cap" >&2
+                echo "       raise it with --max-gpus ${uncapped} (or pick a larger-VRAM GPU)" >&2
+            else
+                echo "error: ${quant} will not fit on any valid GPU count of ${gpu}" >&2
+                echo "       (need ${REMVLLM_QUANT_VRAM[$quant]:-?} GB; ${gpu} = ${REMVLLM_GPU_VRAM[$gpu]:-?} GB/GPU, max TP ${REMVLLM_VALID_TP[-1]})" >&2
+            fi
             return 1
         fi
         local cost
@@ -91,18 +112,23 @@ sizing_plan() {
         fi
     done
     if [[ -z "${best_gpu}" ]]; then
-        echo "error: ${quant} does not fit on any known GPU type" >&2
+        echo "error: ${quant} does not fit any GPU type within the ${cap}-GPU cap" >&2
+        echo "       raise it with --max-gpus (e.g. fp8 GLM-5.2 needs 8), or use int4" >&2
         return 1
     fi
     printf '%s %s %s %s\n' "${best_gpu}" "${best_count}" "${best_count}" "${best_cost}"
 }
 
-# Render the full cost matrix for a quant (human-readable). Marks the auto pick.
+# Render the full cost matrix for a quant (human-readable). Marks the auto pick
+# and flags combos that fit only by exceeding the GPU cap.
 sizing_matrix() {
     local quant="$1" pricing="${2:-spot}"
-    local pick g count cost
-    pick="$(sizing_plan "${quant}" auto "${pricing}" 2>/dev/null | awk '{print $1}')"
-    printf 'quant=%s  pricing=%s\n' "${quant}" "${pricing}"
+    local cap="${REMVLLM_MAX_GPUS:-${REMVLLM_MAX_GPUS_DEFAULT}}"
+    local pick g count cost uncapped
+    # `|| true`: when nothing fits the cap, sizing_plan fails; the matrix must
+    # still render (showing why), so don't let set -e/pipefail abort here.
+    pick="$(sizing_plan "${quant}" auto "${pricing}" 2>/dev/null | awk '{print $1}')" || true
+    printf 'quant=%s  pricing=%s  cap=%s GPUs\n' "${quant}" "${pricing}" "${cap}"
     printf '  %-6s %-6s %-6s %-10s\n' GPU COUNT TP "$(printf '$%s/hr' "${pricing}")"
     for g in "${REMVLLM_GPU_TYPES[@]}"; do
         if count="$(sizing_gpu_count "${quant}" "${g}")"; then
@@ -110,6 +136,8 @@ sizing_matrix() {
             printf '  %-6s %-6s %-6s %-10s%s\n' \
                 "${g}" "${count}" "${count}" "${cost}" \
                 "$([[ "${g}" == "${pick}" ]] && printf '  <- cheapest' || true)"
+        elif uncapped="$(sizing_count_within "${quant}" "${g}" "${REMVLLM_VALID_TP[-1]}")"; then
+            printf '  %-6s %-6s %-6s %-10s\n' "${g}" "-" "-" "needs ${uncapped} (>cap)"
         else
             printf '  %-6s %-6s %-6s %-10s\n' "${g}" "-" "-" "will not fit"
         fi

--- a/ops/terraform/remvllm/lib/state.sh
+++ b/ops/terraform/remvllm/lib/state.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# state.sh — per-hostname runtime state for remvllm.
+#
+# State lives at <state_dir>/<hostname>/state.json so two machines can manage
+# their own remote nodes independently. The whole state/ tree is gitignored.
+# Prerequisites: jq.
+# Side effects: reads/writes files under the state dir.
+
+# --- Action functions --------------------------------------------------------
+
+# Echo the state directory for this host, creating it if needed.
+state_host_dir() {
+    local base="$1"
+    local host="${REMVLLM_FAKE_HOSTNAME:-$(hostname -s 2>/dev/null || hostname)}"
+    local dir="${base}/${host}"
+    mkdir -p "${dir}"
+    printf '%s\n' "${dir}"
+}
+
+# Echo the path to this host's state.json.
+state_file() {
+    local base="$1"
+    printf '%s/state.json\n' "$(state_host_dir "${base}")"
+}
+
+# --- Flow functions ----------------------------------------------------------
+
+# Write a state.json from key=value pairs. Numbers and booleans are passed
+# through as JSON; everything else is a string. Usage:
+#   state_write <base> instance_id=spheron-abc gpu_count=8 spot=true ...
+state_write() {
+    local base="$1"; shift
+    local file
+    file="$(state_file "${base}")"
+    local jq_args=() filter="{}" pair key val
+    for pair in "$@"; do
+        key="${pair%%=*}"
+        val="${pair#*=}"
+        if [[ "${val}" =~ ^-?[0-9]+(\.[0-9]+)?$ || "${val}" == "true" || "${val}" == "false" || "${val}" == "null" ]]; then
+            filter="${filter} | .${key} = ${val}"
+        else
+            jq_args+=(--arg "${key}" "${val}")
+            filter="${filter} | .${key} = \$${key}"
+        fi
+    done
+    jq -n "${jq_args[@]}" "${filter}" > "${file}"
+}
+
+# Echo a single field from state.json, or empty if absent.
+state_read() {
+    local base="$1" field="$2"
+    local file
+    file="$(state_file "${base}")"
+    [[ -f "${file}" ]] || return 0
+    jq -r --arg f "${field}" '.[$f] // empty' "${file}"
+}
+
+# Return 0 if a state.json exists with a non-empty instance_id.
+state_has_instance() {
+    local base="$1"
+    [[ -n "$(state_read "${base}" instance_id)" ]]
+}
+
+# Remove this host's state.json.
+state_clear() {
+    local base="$1"
+    rm -f "$(state_file "${base}")"
+}

--- a/ops/terraform/remvllm/lib/tunnel.sh
+++ b/ops/terraform/remvllm/lib/tunnel.sh
@@ -3,7 +3,7 @@
 #
 # Forwards localhost:<local_port> -> remote vLLM <remote_port>. The remote binds
 # vLLM to localhost only, so the tunnel is the sole access path.
-# Prerequisites: ssh.
+# Prerequisites: ssh, curl (endpoint readiness probe), pgrep (tunnel pid discovery).
 # Side effects: spawns/kills a background ssh process; writes the pid to state.
 
 # --- Action functions --------------------------------------------------------

--- a/ops/terraform/remvllm/lib/tunnel.sh
+++ b/ops/terraform/remvllm/lib/tunnel.sh
@@ -39,5 +39,7 @@ tunnel_open() {
         "root@${host}"
     # `ssh -f` backgrounds itself; find the listener pid for our local port.
     # `-n` selects the newest match, so a stale prior tunnel can't be recorded.
-    pgrep -n -f "ssh.*-L ${local_port}:localhost:${remote_port}"
+    # `|| true`: pgrep exits non-zero when there's no match, which would abort
+    # the caller's `remvllm run` under set -e; an empty pid is handled there.
+    pgrep -n -f "ssh.*-L ${local_port}:localhost:${remote_port}" || true
 }

--- a/ops/terraform/remvllm/lib/tunnel.sh
+++ b/ops/terraform/remvllm/lib/tunnel.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# tunnel.sh — SSH tunnel management for the local OpenAI-compatible endpoint.
+#
+# Forwards localhost:<local_port> -> remote vLLM <remote_port>. The remote binds
+# vLLM to localhost only, so the tunnel is the sole access path.
+# Prerequisites: ssh.
+# Side effects: spawns/kills a background ssh process; writes the pid to state.
+
+# --- Action functions --------------------------------------------------------
+
+# Return 0 if the local endpoint answers an OpenAI-compatible health/models probe.
+tunnel_endpoint_ready() {
+    local local_port="$1"
+    curl -fsS --max-time 3 "http://localhost:${local_port}/v1/models" >/dev/null 2>&1
+}
+
+# Kill a tunnel by pid if it is still alive.
+tunnel_kill() {
+    local pid="$1"
+    [[ -n "${pid}" ]] || return 0
+    if kill -0 "${pid}" 2>/dev/null; then
+        kill "${pid}" 2>/dev/null || true
+    fi
+}
+
+# --- Flow functions ----------------------------------------------------------
+
+# Open a background SSH tunnel. Echoes the tunnel pid on success.
+# Usage: tunnel_open <host> <ssh_port> <local_port> <remote_port> <key_file>
+tunnel_open() {
+    local host="$1" ssh_port="$2" local_port="$3" remote_port="$4" key_file="$5"
+    ssh -f -N \
+        -o StrictHostKeyChecking=accept-new \
+        -o ExitOnForwardFailure=yes \
+        -o ServerAliveInterval=15 \
+        -i "${key_file}" \
+        -p "${ssh_port}" \
+        -L "${local_port}:localhost:${remote_port}" \
+        "root@${host}"
+    # `ssh -f` backgrounds itself; find the listener pid for our local port.
+    pgrep -f "ssh.*-L ${local_port}:localhost:${remote_port}" | head -n1
+}

--- a/ops/terraform/remvllm/lib/tunnel.sh
+++ b/ops/terraform/remvllm/lib/tunnel.sh
@@ -38,5 +38,6 @@ tunnel_open() {
         -L "${local_port}:localhost:${remote_port}" \
         "root@${host}"
     # `ssh -f` backgrounds itself; find the listener pid for our local port.
-    pgrep -f "ssh.*-L ${local_port}:localhost:${remote_port}" | head -n1
+    # `-n` selects the newest match, so a stale prior tunnel can't be recorded.
+    pgrep -n -f "ssh.*-L ${local_port}:localhost:${remote_port}"
 }

--- a/ops/terraform/remvllm/lib/watchdog.sh
+++ b/ops/terraform/remvllm/lib/watchdog.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# watchdog.sh — client-side TTL enforcement (the "suspenders").
+#
+# The server-side watchdog (container/watchdog.sh) is the "belt": it self-
+# destructs the node when no SSH session is present. This client watchdog tears
+# the node down when the TTL expires AND the endpoint is idle, extending a grace
+# window if a request is in flight.
+# Prerequisites: bash, date.
+# Side effects: invokes the orchestrator's teardown when TTL lapses.
+
+# --- Action functions --------------------------------------------------------
+
+# Echo epoch seconds for an ISO-8601 timestamp (GNU or BSD date).
+watchdog_epoch() {
+    local ts="$1"
+    date -d "${ts}" +%s 2>/dev/null || date -j -f "%Y-%m-%dT%H:%M:%SZ" "${ts}" +%s 2>/dev/null
+}
+
+# Return 0 if `now` is at or past `expiry` (both ISO-8601).
+watchdog_expired() {
+    local expiry="$1" now="${2:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+    local e n
+    e="$(watchdog_epoch "${expiry}")"
+    n="$(watchdog_epoch "${now}")"
+    [[ -n "${e}" && -n "${n}" ]] || return 1
+    (( n >= e ))
+}
+
+# Echo an ISO-8601 timestamp `minutes` from now (UTC).
+watchdog_ttl_from_now() {
+    local minutes="$1"
+    date -u -d "+${minutes} minutes" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || date -u -v "+${minutes}M" +%Y-%m-%dT%H:%M:%SZ
+}

--- a/ops/terraform/remvllm/modules/spheron/main.tf
+++ b/ops/terraform/remvllm/modules/spheron/main.tf
@@ -1,0 +1,40 @@
+# main.tf — Spheron multi-GPU spot node for the remvllm appliance.
+#
+# Contract: "get me gpu_count GPUs of gpu_type on a SPOT node that can run podman
+# with GPU passthrough." cloud-init installs podman + nvidia-container-toolkit
+# and runs the appliance container. Mirrors the remollama Spheron module, with
+# multi-GPU and spot pricing added.
+
+terraform {
+  required_providers {
+    spheron = {
+      source  = "spheronFdn/spheron"
+      version = ">= 1.0.0"
+    }
+  }
+}
+
+provider "spheron" {
+  token = var.provider_token
+}
+
+resource "spheron_instance" "remvllm" {
+  name = var.instance_name
+
+  # Sizer-driven multi-GPU request.
+  gpu_type  = var.gpu_type
+  gpu_count = var.gpu_count
+
+  # Cheapest-first: spot by default, optional price cap.
+  spot      = var.spot
+  max_price = var.max_price > 0 ? var.max_price : null
+
+  ssh_public_key = var.ssh_public_key
+
+  # cloud-init: install podman + nvidia-container-toolkit, run the appliance.
+  user_data = templatefile("${path.module}/scripts/bootstrap.sh", {
+    container_image = var.container_image
+    ssh_public_key  = var.ssh_public_key
+    env_vars        = var.env_vars
+  })
+}

--- a/ops/terraform/remvllm/modules/spheron/outputs.tf
+++ b/ops/terraform/remvllm/modules/spheron/outputs.tf
@@ -1,0 +1,16 @@
+# outputs.tf — provider-agnostic contract outputs.
+
+output "host" {
+  value       = spheron_instance.remvllm.ip
+  description = "Instance IP or hostname"
+}
+
+output "ssh_port" {
+  value       = spheron_instance.remvllm.ssh_port
+  description = "SSH port on the instance"
+}
+
+output "instance_id" {
+  value       = spheron_instance.remvllm.id
+  description = "Provider-specific instance identifier"
+}

--- a/ops/terraform/remvllm/modules/spheron/scripts/bootstrap.sh
+++ b/ops/terraform/remvllm/modules/spheron/scripts/bootstrap.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# bootstrap.sh — cloud-init for a Spheron GPU node (templated by terraform).
+#
+# Installs podman + nvidia-container-toolkit, then runs the remvllm appliance
+# with GPU passthrough. Templated variables: container_image, ssh_public_key.
+set -euo pipefail
+
+CONTAINER_IMAGE="${container_image}"
+SSH_PUBLIC_KEY="${ssh_public_key}"
+
+install_runtime() {
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -y
+    apt-get install -y podman curl gnupg ca-certificates
+
+    # nvidia-container-toolkit for GPU passthrough into podman.
+    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
+        | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
+    curl -fsSL https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list \
+        | sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' \
+        > /etc/apt/sources.list.d/nvidia-container-toolkit.list
+    apt-get update -y
+    apt-get install -y nvidia-container-toolkit
+    nvidia-ctk runtime configure --runtime=podman || true
+}
+
+run_appliance() {
+    podman pull "$${CONTAINER_IMAGE}"
+    podman run -d --name remvllm \
+        --device nvidia.com/gpu=all \
+        --security-opt=label=disable \
+        -e SSH_PUBLIC_KEY="$${SSH_PUBLIC_KEY}" \
+        -p 22:22 \
+        "$${CONTAINER_IMAGE}"
+}
+
+main() {
+    install_runtime
+    run_appliance
+}
+
+main "$@"

--- a/ops/terraform/remvllm/modules/spheron/variables.tf
+++ b/ops/terraform/remvllm/modules/spheron/variables.tf
@@ -1,0 +1,50 @@
+# variables.tf — provider-agnostic contract inputs (+ multi-GPU/spot extensions).
+
+variable "gpu_type" {
+  type        = string
+  description = "GPU tier: a100 | h100 | h200 | b200"
+}
+
+variable "gpu_count" {
+  type        = number
+  description = "Number of GPUs (tensor-parallel size), from the remvllm sizer"
+}
+
+variable "spot" {
+  type        = bool
+  default     = true
+  description = "Provision a spot/preemptible node (cheapest; may be reclaimed)"
+}
+
+variable "max_price" {
+  type        = number
+  default     = 0
+  description = "Max spot price per hour (0 = provider default / no cap)"
+}
+
+variable "container_image" {
+  type        = string
+  description = "Appliance image to run (vLLM + sshd + watchdog)"
+}
+
+variable "ssh_public_key" {
+  type        = string
+  description = "SSH public key injected for tunnel access"
+}
+
+variable "provider_token" {
+  type        = string
+  sensitive   = true
+  description = "Spheron API credential (from 1Password at runtime)"
+}
+
+variable "instance_name" {
+  type        = string
+  description = "Name tag for the instance"
+}
+
+variable "env_vars" {
+  type        = map(string)
+  default     = {}
+  description = "Environment variables for the appliance container"
+}

--- a/ops/terraform/remvllm/recipes/glm-5.2/recipe.conf
+++ b/ops/terraform/remvllm/recipes/glm-5.2/recipe.conf
@@ -1,0 +1,20 @@
+# recipe.conf — GLM-5.2 launch recipe for remvllm.
+#
+# A recipe is the vLLM analogue of an Ollama Modelfile: the model id plus the
+# serve-time parameters. Sourced by the appliance to build the `vllm serve`
+# command line. Tensor-parallel size and dtype come from the sizer + quant, not
+# from here.
+
+RECIPE_MODEL_ID="zai-org/GLM-5.2"
+RECIPE_SERVED_NAME="glm-5.2"
+
+# Context window. GLM-5.2 supports up to 1M tokens, but KV cache for 1M is huge;
+# default to a sane window and raise per-invocation if the VRAM headroom exists.
+RECIPE_MAX_MODEL_LEN=131072
+
+# MoE expert parallelism is essential for GLM-5 throughput; trust-remote-code is
+# required to load the GLM-5 model definition.
+RECIPE_EXTRA_ARGS="--enable-expert-parallel --trust-remote-code"
+
+# System prompt is applied client-side per request, not baked into the server.
+RECIPE_SYSTEM="You are GLM-5.2, a concise, capable coding and reasoning assistant."

--- a/ops/terraform/remvllm/remvllm.conf
+++ b/ops/terraform/remvllm/remvllm.conf
@@ -1,0 +1,38 @@
+# remvllm.conf — checked-in defaults for the remote vLLM orchestrator.
+#
+# Precedence (lowest to highest): this file < remvllm.local.conf < environment.
+# Copy machine-specific overrides into remvllm.local.conf (gitignored), and use
+# environment variables for one-off overrides.
+
+# --- Lifecycle / spend ---
+REMVLLM_TTL_MINUTES=20              # Default TTL for an invocation
+REMVLLM_GRACE_MINUTES=5             # Courtesy window after a request completes
+REMVLLM_WATCHDOG_TIMEOUT=600        # Server-side: seconds w/o SSH -> self-destruct
+
+# --- Provisioning ---
+REMVLLM_PROVIDER=spheron            # Which terraform module to use
+REMVLLM_SPOT=true                   # Cheapest-first: spot/preemptible by default
+REMVLLM_GPU_TYPE=auto               # auto = sizer picks the cheapest GPU that fits
+REMVLLM_QUANT=int4                  # int4 (cheapest) | fp8 (reference quality)
+REMVLLM_REGION=any
+
+# --- Engine / endpoint ---
+REMVLLM_LOCAL_PORT=8000             # Local OpenAI-compatible endpoint port
+REMVLLM_REMOTE_PORT=8000            # vLLM port inside the appliance
+
+# --- Model weight cache (download from HF exactly once) ---
+REMVLLM_BUCKET_PROVIDER=r2          # r2 (zero egress, default) | s3
+REMVLLM_BUCKET_NAME=""              # e.g. remvllm-weights   (set in .local.conf)
+REMVLLM_BUCKET_URL=""               # e.g. r2:remvllm-weights (rclone remote:bucket)
+
+# --- 1Password (op://) secret paths (override in .local.conf) ---
+REMVLLM_SPHERON_OP_TOKEN="op://Private/Spheron/credential"
+REMVLLM_SPHERON_OP_SSH_KEY="op://Private/spheron-ssh/private_key"
+REMVLLM_SPHERON_OP_SSH_PUBKEY="op://Private/spheron-ssh/public_key"
+REMVLLM_OP_HF_TOKEN="op://Private/HuggingFace/token"
+REMVLLM_OP_BUCKET_ACCESS_KEY="op://Private/remvllm-bucket/access_key"
+REMVLLM_OP_BUCKET_SECRET_KEY="op://Private/remvllm-bucket/secret_key"
+REMVLLM_OP_BUCKET_ENDPOINT="op://Private/remvllm-bucket/endpoint"
+
+# --- State ---
+REMVLLM_STATE_DIR=""                # Override state dir (default: <ops>/state)

--- a/ops/terraform/remvllm/remvllm.conf
+++ b/ops/terraform/remvllm/remvllm.conf
@@ -14,6 +14,7 @@ REMVLLM_PROVIDER=spheron            # Which terraform module to use
 REMVLLM_SPOT=true                   # Cheapest-first: spot/preemptible by default
 REMVLLM_GPU_TYPE=auto               # auto = sizer picks the cheapest GPU that fits
 REMVLLM_QUANT=int4                  # int4 (cheapest) | fp8 (reference quality)
+REMVLLM_MAX_GPUS=4                  # Target-platform ceiling (single-node sweet spot)
 REMVLLM_REGION=any
 
 # --- Engine / endpoint ---

--- a/test/smoketest_remvllm/01_sizing_picks_cheapest.sh
+++ b/test/smoketest_remvllm/01_sizing_picks_cheapest.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 # 01_sizing_picks_cheapest.sh
-# Given quant int4 (the cheap default), When the sizer auto-picks, Then it
-# returns the lowest-cost spot config that fits (8x a100). For fp8 the cheapest
-# fit is 8x h200.
+# Given the default 4-GPU cap, When the sizer auto-picks int4, Then it returns
+# the cheapest single-node fit (4x h200) — A100 is excluded because it would
+# need 8 GPUs. Raising the cap to 8 brings the cheaper 8x a100 back.
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -10,11 +10,14 @@ source "${SCRIPT_DIR}/config.sh"
 
 main() {
     local plan
+    # Default cap (4): cheapest int4 fit is 4x h200.
     plan="$(sizing_plan int4 auto spot)"
-    assert_eq "${plan}" "a100 8 8 5.28" "int4 auto pick should be cheapest spot fit"
+    assert_eq "${plan}" "h200 4 4 7.08" "int4 auto pick under 4-GPU cap should be 4x h200"
 
-    plan="$(sizing_plan fp8 auto spot)"
-    assert_eq "${plan}" "h200 8 8 14.16" "fp8 auto pick should be cheapest fp8 fit"
+    # Override the cap to 8: the cheaper 8x a100 config becomes eligible again.
+    plan="$( REMVLLM_MAX_GPUS=8 bash -c '
+        source "'"${LIB_DIR}"'/sizing.sh"; sizing_plan int4 auto spot' )"
+    assert_eq "${plan}" "a100 8 8 5.28" "raising cap to 8 should re-admit 8x a100"
 }
 
 main "$@"

--- a/test/smoketest_remvllm/01_sizing_picks_cheapest.sh
+++ b/test/smoketest_remvllm/01_sizing_picks_cheapest.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# 01_sizing_picks_cheapest.sh
+# Given quant int4 (the cheap default), When the sizer auto-picks, Then it
+# returns the lowest-cost spot config that fits (8x a100). For fp8 the cheapest
+# fit is 8x h200.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    local plan
+    plan="$(sizing_plan int4 auto spot)"
+    assert_eq "${plan}" "a100 8 8 5.28" "int4 auto pick should be cheapest spot fit"
+
+    plan="$(sizing_plan fp8 auto spot)"
+    assert_eq "${plan}" "h200 8 8 14.16" "fp8 auto pick should be cheapest fp8 fit"
+}
+
+main "$@"

--- a/test/smoketest_remvllm/02_sizing_respects_flags.sh
+++ b/test/smoketest_remvllm/02_sizing_respects_flags.sh
@@ -1,23 +1,36 @@
 #!/usr/bin/env bash
 # 02_sizing_respects_flags.sh
-# Given an explicit --gpu, When it can fit the quant, Then the sizer uses it;
-# When it cannot (fp8 on a100, 8x80GB < 860GB), Then the sizer REJECTS it.
+# The GPU cap and explicit flags constrain the sizer:
+#  - int4 on h200 fits in 4 GPUs (the target platform);
+#  - int4 on a100 is REJECTED under the default cap (needs 8, over the cap);
+#  - fp8 GLM-5.2 is REJECTED under the default cap (needs 8 of anything), but
+#    fits 8x h200 once the cap is raised;
+#  - fp8 on a100 never fits, cap or no cap.
 
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/config.sh"
 
 main() {
-    # int4 on h200 fits at TP 4.
+    # int4 on h200 fits at TP 4 — the single-node sweet spot.
     local plan
     plan="$(sizing_plan int4 h200 spot)"
     assert_eq "${plan}" "h200 4 4 7.08" "int4 on h200 should size to 4 GPUs"
 
-    # fp8 does not fit on any valid a100 count -> must fail loudly.
-    assert_fails sizing_plan fp8 a100 spot
+    # int4 on a100 needs 8 GPUs -> over the default 4-GPU cap -> rejected.
+    assert_fails sizing_plan int4 a100 spot
 
-    # The underlying capacity check also rejects it.
-    assert_fails sizing_gpu_count fp8 a100
+    # fp8 needs ~860 GB (8 GPUs) -> over the default cap -> rejected.
+    assert_fails sizing_plan fp8 auto spot
+
+    # Raising the cap to 8 lets fp8 land on 8x h200.
+    plan="$( REMVLLM_MAX_GPUS=8 bash -c '
+        source "'"${LIB_DIR}"'/sizing.sh"; sizing_plan fp8 auto spot' )"
+    assert_eq "${plan}" "h200 8 8 14.16" "fp8 should fit 8x h200 once cap is raised"
+
+    # fp8 never fits on a100 (8x80=640 < 860), even with the cap raised.
+    assert_fails env REMVLLM_MAX_GPUS=8 bash -c '
+        source "'"${LIB_DIR}"'/sizing.sh"; sizing_gpu_count fp8 a100'
 }
 
 main "$@"

--- a/test/smoketest_remvllm/02_sizing_respects_flags.sh
+++ b/test/smoketest_remvllm/02_sizing_respects_flags.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# 02_sizing_respects_flags.sh
+# Given an explicit --gpu, When it can fit the quant, Then the sizer uses it;
+# When it cannot (fp8 on a100, 8x80GB < 860GB), Then the sizer REJECTS it.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    # int4 on h200 fits at TP 4.
+    local plan
+    plan="$(sizing_plan int4 h200 spot)"
+    assert_eq "${plan}" "h200 4 4 7.08" "int4 on h200 should size to 4 GPUs"
+
+    # fp8 does not fit on any valid a100 count -> must fail loudly.
+    assert_fails sizing_plan fp8 a100 spot
+
+    # The underlying capacity check also rejects it.
+    assert_fails sizing_gpu_count fp8 a100
+}
+
+main "$@"

--- a/test/smoketest_remvllm/03_config_layering.sh
+++ b/test/smoketest_remvllm/03_config_layering.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# 03_config_layering.sh
+# Given defaults in remvllm.conf and overrides in remvllm.local.conf and the
+# environment, When config_load runs, Then precedence is conf < local < env.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    # Global (not local) so the EXIT trap can see it after main returns.
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "${tmp}"' EXIT
+
+    cat > "${tmp}/remvllm.conf" <<'EOF'
+REMVLLM_QUANT=int4
+REMVLLM_TTL_MINUTES=20
+REMVLLM_GPU_TYPE=auto
+EOF
+    cat > "${tmp}/remvllm.local.conf" <<'EOF'
+REMVLLM_QUANT=fp8
+EOF
+
+    # Environment override (highest precedence).
+    export REMVLLM_TTL_MINUTES=99
+
+    config_load "${tmp}"
+
+    assert_eq "${REMVLLM_QUANT}" "fp8" "local.conf should override conf"
+    assert_eq "${REMVLLM_TTL_MINUTES}" "99" "environment should override both files"
+    assert_eq "${REMVLLM_GPU_TYPE}" "auto" "unoverridden default should survive"
+}
+
+main "$@"

--- a/test/smoketest_remvllm/04_state_roundtrip.sh
+++ b/test/smoketest_remvllm/04_state_roundtrip.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# 04_state_roundtrip.sh
+# Given a written state record, When read back, Then strings/numbers/booleans
+# round-trip and state_has_instance / state_clear behave.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    if ! command -v jq >/dev/null 2>&1; then
+        echo "skip: jq not on PATH"
+        return 0
+    fi
+
+    # Global (not local) so the EXIT trap can see it after main returns.
+    base="$(mktemp -d)"
+    trap 'rm -rf "${base}"' EXIT
+    export REMVLLM_FAKE_HOSTNAME="testhost"
+
+    # Absent before any write.
+    assert_fails state_has_instance "${base}"
+
+    state_write "${base}" \
+        instance_id="spheron-abc123" gpu_type="a100" gpu_count=8 \
+        spot=true est_cost_hr=5.28 recipe="glm-5.2"
+
+    state_has_instance "${base}" || { echo "FAIL: instance should exist"; return 1; }
+    assert_eq "$(state_read "${base}" instance_id)" "spheron-abc123" "string field"
+    assert_eq "$(state_read "${base}" gpu_count)"   "8"              "number field"
+    assert_eq "$(state_read "${base}" spot)"        "true"           "boolean field"
+    assert_eq "$(state_read "${base}" est_cost_hr)" "5.28"           "float field"
+    assert_eq "$(state_read "${base}" missing)"     ""               "absent field is empty"
+
+    state_clear "${base}"
+    assert_fails state_has_instance "${base}"
+}
+
+main "$@"

--- a/test/smoketest_remvllm/05_modelcache_uri.sh
+++ b/test/smoketest_remvllm/05_modelcache_uri.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# 05_modelcache_uri.sh
+# Given a model id, When addressing the bucket cache, Then the key is sanitized
+# and the URI is namespaced by quant (so HF is only ever a fallback).
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/config.sh"
+
+main() {
+    assert_eq "$(modelcache_key 'zai-org/GLM-5.2')" \
+        "zai-org__GLM-5.2" "slash should be sanitized to __"
+
+    assert_eq "$(modelcache_uri 'r2:remvllm-weights' 'zai-org/GLM-5.2')" \
+        "r2:remvllm-weights/models/zai-org__GLM-5.2" "base uri"
+
+    assert_eq "$(modelcache_uri 'r2:remvllm-weights' 'zai-org/GLM-5.2' 'int4')" \
+        "r2:remvllm-weights/models/zai-org__GLM-5.2/int4" "quant-namespaced uri"
+
+    # Trailing slash on the bucket URL must not double up.
+    assert_eq "$(modelcache_uri 'r2:remvllm-weights/' 'zai-org/GLM-5.2')" \
+        "r2:remvllm-weights/models/zai-org__GLM-5.2" "trailing slash normalized"
+}
+
+main "$@"

--- a/test/smoketest_remvllm/config.sh
+++ b/test/smoketest_remvllm/config.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# config.sh — shared environment + helpers for remvllm smoke tests.
+#
+# Hermetic: pure-logic libs only (sizing, state, modelcache, config). No network,
+# no cloud, no op/terraform/ssh. Sourcing is side-effect-free; each scenario
+# sources this file, then asserts behavior through the public lib functions.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+LIB_DIR="${REPO_DIR}/ops/terraform/remvllm/lib"
+
+# shellcheck source=../../ops/terraform/remvllm/lib/sizing.sh
+source "${LIB_DIR}/sizing.sh"
+# shellcheck source=../../ops/terraform/remvllm/lib/state.sh
+source "${LIB_DIR}/state.sh"
+# shellcheck source=../../ops/terraform/remvllm/lib/modelcache.sh
+source "${LIB_DIR}/modelcache.sh"
+# shellcheck source=../../ops/terraform/remvllm/lib/config.sh
+source "${LIB_DIR}/config.sh"
+
+# --- Assertion helpers -------------------------------------------------------
+
+assert_eq() {
+    local got="$1" want="$2" msg="${3:-}"
+    if [[ "${got}" != "${want}" ]]; then
+        echo "FAIL: ${msg}"
+        echo "  got:  '${got}'"
+        echo "  want: '${want}'"
+        return 1
+    fi
+}
+
+# Run a command expected to FAIL (non-zero). Fails the test if it succeeds.
+assert_fails() {
+    if "$@" >/dev/null 2>&1; then
+        echo "FAIL: expected non-zero exit from: $*"
+        return 1
+    fi
+}

--- a/test/smoketest_remvllm/run_all.sh
+++ b/test/smoketest_remvllm/run_all.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# run_all.sh — orchestrate remvllm unit smoke tests.
+#
+# Hermetic and fast: pure-logic libs only, no network/cloud. Each scenario is a
+# standalone process. Usage: ./test/smoketest_remvllm/run_all.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- Test harness (definitions; control flow lives in main) ------------------
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+red()   { printf "\033[1;31m%s\033[0m" "$1"; }
+green() { printf "\033[1;32m%s\033[0m" "$1"; }
+bold()  { printf "\033[1m%s\033[0m" "$1"; }
+
+run_test() {
+    local script="$1" name
+    name="$(basename "${script}" .sh)"
+    TESTS_RUN=$((TESTS_RUN + 1))
+    printf "  %s ... " "$(bold "${name}")"
+    if ( bash "${script}" ); then
+        printf "%s\n" "$(green PASS)"
+        TESTS_PASSED=$((TESTS_PASSED + 1))
+    else
+        printf "%s\n" "$(red FAIL)"
+        TESTS_FAILED=$((TESTS_FAILED + 1))
+    fi
+}
+
+# --- Main --------------------------------------------------------------------
+
+main() {
+    printf "remvllm smoke tests\n"
+    local script
+    for script in "${SCRIPT_DIR}"/[0-9][0-9]_*.sh; do
+        [[ -f "${script}" ]] || continue
+        run_test "${script}"
+    done
+    printf "\n%d run, %d passed, %d failed\n" \
+        "${TESTS_RUN}" "${TESTS_PASSED}" "${TESTS_FAILED}"
+    [[ "${TESTS_FAILED}" -eq 0 ]]
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Introduces `remvllm`, a sister tool to `remollama` that provisions multi-GPU spot nodes, serves large open-weight models (GLM-5.2 by default) with vLLM, and exposes an OpenAI-compatible API via SSH tunnel. Designed for cost-efficiency: spot instances by default, weights cached in object storage (R2/S3) so Hugging Face is downloaded exactly once, and a cost-driven sizer that picks the cheapest GPU configuration that fits.

## Key Changes

- **CLI entry point** (`bin/remvllm`): Commands for `run`, `stop`, `destroy`, `status`, `sizes`, `cache`, and `list-recipes`. Supports flags for GPU type, quantization, TTL, and spot/on-demand selection.

- **Orchestration layer** (`lib/orchestrate.sh`): Lifecycle management—provisions nodes via Terraform, detects spot preemption and re-provisions, opens SSH tunnels, and manages state.

- **Cost-driven sizing** (`lib/sizing.sh`): Data-driven sizer with GPU VRAM and pricing tables. Computes the smallest tensor-parallel configuration that fits a quantized model within a GPU cap (default 4 GPUs, single-node sweet spot). Auto-picks the cheapest GPU type or validates explicit selections.

- **Model cache** (`lib/modelcache.sh`, `container/fetch-model.sh`): Bucket-backed weight cache (R2/S3 via rclone). Hugging Face is hit only on first cold start to populate the bucket; all subsequent nodes pull from the bucket, making recovery from spot preemption fast and cheap.

- **State management** (`lib/state.sh`): Per-hostname JSON state tracking instance metadata, TTL, cost estimates, and tunnel PID. Enables reconnection to live nodes and cleanup on preemption.

- **Configuration layering** (`lib/config.sh`): Three-tier precedence (defaults < local overrides < environment) for flexible per-machine and per-invocation tuning.

- **Secrets integration** (`lib/secrets.sh`): 1Password (`op`) resolution for provider tokens, SSH keys, HF tokens, and bucket credentials—never written to disk.

- **SSH tunnel management** (`lib/tunnel.sh`): Opens background SSH port-forward tunnels, probes endpoint readiness, and manages tunnel lifecycle.

- **Client/server watchdogs** (`lib/watchdog.sh`, `container/watchdog.sh`): Client-side TTL enforcement with grace window; server-side idle monitor that self-destructs the node if no SSH session is active.

- **Appliance container** (`container/`): Dockerfile-based image with vLLM, sshd, rclone, and watchdog. Entrypoint orchestrates SSH key setup, model fetch, and vLLM serve with tensor/expert parallelism.

- **Terraform provisioning** (`modules/spheron/`): Spheron provider module for multi-GPU spot nodes. Contracts on GPU type/count, spot pricing, and cloud-init bootstrap. Outputs host, SSH port, and instance ID.

- **Recipe system** (`recipes/glm-5.2/`): Model-specific launch configuration (model ID, served name, context window, quantization defaults).

- **Smoke tests** (`test/smoketest_remvllm/`): Hermetic unit tests for sizing logic, config layering, state round-tripping, and model cache URI generation. No network/cloud dependencies.

## Notable Design Decisions

- **4-GPU single-node target**: Balances cost, availability, and performance. Larger configs (8 GPUs) are opt-in via `--max-gpus` to avoid scarce/preemption-prone spot inventory.
- **int4 as default quant**: Fits 4×h200 (~$7.08/hr). fp8 requires 8 GPUs and is opt-in.
- **Spot-first with preemption tolerance**: Nodes are expected to be reclaimed; recovery is fast because weights are cached.
- **Bucket-backed cache**: Eliminates repeated Hugging Face downloads and makes cold starts after preemption

https://claude.ai/code/session_016T8xKCVmVmWKRPzooGh3wP